### PR TITLE
Rename repo from "nupic.cpp" to "htm.core"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 # See https://help.github.com/articles/dealing-with-line-endings/
 #     https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
 #
-# In general for htm.cpp repository, line endings should remain Linux oriented.
+# In general for htm.core repository, line endings should remain Linux oriented.
 # For Text files this will enforce use of lf rather than crlf in the repository.  
 # Doing so make it much easier to avoid unexpected whitespace changes.
 #

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 # See https://help.github.com/articles/dealing-with-line-endings/
 #     https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
 #
-# In general for nupic.cpp repository, line endings should remain Linux oriented.
+# In general for htm.cpp repository, line endings should remain Linux oriented.
 # For Text files this will enforce use of lf rather than crlf in the repository.  
 # Doing so make it much easier to avoid unexpected whitespace changes.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ htmlcov/
 # KDevelop
 .kdev4
 nupic.core.kdev4
+htm.core.kdev4
 
 # Eclipse project files
 .cproject

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -1,7 +1,7 @@
-# Breaking changes to the htm API
+# Breaking changes to the NuPIC API
 
-We try to keep API as much as compatible with original [numenta/nupic.core repo](https://github.com/numenta/nupic.core). 
-The API is specified in the [API Docs](http://nupic.docs.numenta.org/prerelease/api/index.html) 
+We try to keep the API compatible with the original [numenta/nupic.core repo](https://github.com/numenta/nupic.core). 
+That API is specified in their [API Docs](http://nupic.docs.numenta.org/prerelease/api/index.html).
 
 ## Motivation
 
@@ -10,6 +10,15 @@ our implementation. And for developers to be easily able to navigate within the 
 Despite of this, sometimes changes need to happen - be it for optimization, removal/replacement of some 
 features or implementation detail, etc.
 
+## Summary
+
+The NetworkAPI is mostly unchanged, since it is a compatibility layer.
+Direct access to the algorithms APIs has changed:
+* All classes now use the `SDR` class where applicable instead of raw data lists.
+* All encoders have new API.
+* `SDRClassifier` split into two classes: `Classifier` and `Predictor` with new API.
+* `Anomaly` class is now built into the `TemporalMemory`
+* `SpatialPooler` & `TemporalMemory` have many small changes, see below.
 
 ## API breaking changes in this repo
 
@@ -59,8 +68,6 @@ are ignored.  PR #271
 
 * Removed `void SpatialPooler::stripUnlearnedColumns()` as unused and not useful (did not effectively remove any columns). PR #286 
 
-* Changed SDRClassifier::compute() signature to take parameter `ClassifierResult& result`, instead of a raw pointer. PR #301
-
 * Rewrote ScalarEncoder API, all code using it needs to be rewritten. PR #314
 
 * Removed old `TP` (Temporal Pooler, `Cells4.hpp`) as it was not maintained, users should default to `TemporalMemory, TM`. 
@@ -77,7 +84,7 @@ longer accept a synapse permanence threshold argument. PR #305
 This is obsolete. Use getRegion('name') instead. 
 
 * Anomaly class removed as obsolete, use `TM.anomaly` which is simpler to use, and `MovingAverage` when you need to emulate 
-  running averages. Internaly the code still uses `computeRawAnomalyScore()` but there's no need to call it directly. `AnomalyLikelihood` 
+  running averages. Internally the code still uses `computeRawAnomalyScore()` but there's no need to call it directly. `AnomalyLikelihood` 
   is still available and can be used in addition to TM.getAnomalyScore(). PR #406 
 
 * TemporalMemory::getPredictiveCells() now returns a SDR. This ensures more convenient API and that the SDR object has correct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+This file is no longer being updated.
+Instead see the [API_CHANGELOG](API_CHANGELOG.md).
+
 ## 1.1.0
 
 * Comunity release

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,15 @@ RUN pip install wheel
 ENV CC gcc-8
 ENV CXX g++-8
 
-ADD . /usr/local/src/nupic.cpp
-WORKDIR /usr/local/src/nupic.cpp
+ADD . /usr/local/src/htm.core
+WORKDIR /usr/local/src/htm.core
 
 # Explicitly specify --cache-dir, --build, and --no-clean so that build
 # artifacts may be extracted from the container later.  Final built python
-# packages can be found in /usr/local/src/nupic.cpp/bindings/py/dist
+# packages can be found in /usr/local/src/htm.core/bindings/py/dist
 RUN pip install \
-#        --cache-dir /usr/local/src/nupic.cpp/pip-cache \
-#        --build /usr/local/src/nupic.cpp/pip-build \
+#        --cache-dir /usr/local/src/htm.core/pip-cache \
+#        --build /usr/local/src/htm.core/pip-build \
 #        --no-clean \
         -r bindings/py/packaging/requirements.txt
 RUN python setup.py install

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Linux/OSX Build Status](https://travis-ci.org/htm-community/htm.core.svg?branch=master)](https://travis-ci.org/htm-community/htm.core)
 [![OSX CircleCI](https://circleci.com/gh/htm-community/htm.core/tree/master.svg?style=svg)](https://circleci.com/gh/htm-community/htm.core/tree/master)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/59f87and1x0ugss9/branch/master?svg=true)](https://ci.appveyor.com/project/htm-community/htm-core/branch/master)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/59f87and1x0ugss9/branch/master?svg=true)](https://ci.appveyor.com/project/htm-community/nupic-cpp/branch/master)
 
 This fork is a community version of the [nupic.core](https://github.com/numenta/nupic.core) C++ repository with Python bindings.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Community NuPIC.cpp repository (formerly [nupic.core](http://github.com/numenta/nupic.core))
 
-[![Linux/OSX Build Status](https://travis-ci.org/htm-community/nupic.cpp.svg?branch=master)](https://travis-ci.org/htm-community/nupic.cpp)
-[![OSX CircleCI](https://circleci.com/gh/htm-community/nupic.cpp/tree/master.svg?style=svg)](https://circleci.com/gh/htm-community/nupic.cpp/tree/master)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/59f87and1x0ugss9/branch/master?svg=true)](https://ci.appveyor.com/project/htm-community/nupic-cpp/branch/master)
+[![Linux/OSX Build Status](https://travis-ci.org/htm-community/htm.core.svg?branch=master)](https://travis-ci.org/htm-community/htm.core)
+[![OSX CircleCI](https://circleci.com/gh/htm-community/htm.core/tree/master.svg?style=svg)](https://circleci.com/gh/htm-community/htm.core/tree/master)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/59f87and1x0ugss9/branch/master?svg=true)](https://ci.appveyor.com/project/htm-community/htm-core/branch/master)
 
 This fork is a community version of the [nupic.core](https://github.com/numenta/nupic.core) C++ repository with Python bindings.
 

--- a/bindings/py/packaging/setup.py
+++ b/bindings/py/packaging/setup.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
   platform = getPlatformInfo()
 
   if platform == DARWIN_PLATFORM and not "ARCHFLAGS" in os.environ:
-    raise Exception("To build NuPIC Core bindings in OS X, you must "
+    raise Exception("To build HTM.Core bindings in OS X, you must "
                     "`export ARCHFLAGS=\"-arch x86_64\"`.")
 
   # Run CMake if extension files are missing.
@@ -238,7 +238,7 @@ if __name__ == "__main__":
     #     https://opensourceforu.com/2010/OS/extending-python-via-shared-libraries
     #     https://docs.python.org/3/library/ctypes.html
     #     https://docs.python.org/2/library/imp.html
-    name="nupic.bindings",
+    name="htm.core",
     version=getExtensionVersion(),
     # This distribution contains platform-specific C++ libraries, but they are not
     # built with distutils. So we must create a dummy Extension object so when we
@@ -258,11 +258,11 @@ if __name__ == "__main__":
       "clean": CleanCommand,
       "test": TestCommand,
     },
-    description="Python bindings for htm-community nupic core.",
-    author="Numenta",
+    description="Python package for htm.core.",
+    author="Numenta & HTM Community",
     author_email="help@numenta.org",
-    url="https://github.com/htm-community/nupic.cpp",
-    long_description = "Numenta Platform for Intelligent Computing HTM-Community nupic core: nupic.bindings.[sdr,encoders,algorithms,engine_internal,math]",
+    url="https://github.com/htm-community/htm.core",
+    long_description = "HTM Community Edition of Numenta's Platform for Intelligent Computing (NuPIC)",
     license = "GNU Affero General Public License v3 or later (AGPLv3+)",
     classifiers=[
       "Programming Language :: Python",

--- a/bindings/py/tests/encoders/rdse_test.py
+++ b/bindings/py/tests/encoders/rdse_test.py
@@ -255,6 +255,6 @@ class RDSE_Test(unittest.TestCase):
         B = R.encode( 987654 )
         assert( A != B )
 
-    @unittest.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
+    @unittest.skip(reason="Known issue: https://github.com/htm-community/htm.core/issues/160")
     def testPickle(self):
         assert(False) # TODO: Unimplemented

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -301,6 +301,6 @@ class ScalarEncoder_Test(unittest.TestCase):
         assert( mtr.activationFrequency.max() < 1.75 * .10 )
         assert( mtr.overlap.min() > .85 )
 
-    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
+    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/htm.core/issues/160")
     def testPickle(self):
         assert(False) # TODO: Unimplemented

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -378,7 +378,7 @@ class SdrTest(unittest.TestCase):
         B.dense = B.dense
         assert(str(B) == "SDR( 100, 100, 1 ) 0, 9999")
 
-    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
+    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/htm.core/issues/160")
     def testPickle(self):
         for sparsity in (0, .3, 1):
             A = SDR((103,))

--- a/external/README.md
+++ b/external/README.md
@@ -1,7 +1,7 @@
-NuPIC Core external libraries
+HTM Core external libraries
 =============================
 
-NuPIC Core depends on a number of external libraries. The download and build of these libraries is 
+HTM Core depends on a number of external libraries. The download and build of these libraries is
 integrated into the cmake-based build of htm.core.  The code that does this are in external/*.cmake
 
 - Boost.cmake   If needed, finds the boost installation 1.69.0. Boost needs to be built with -fPIC so cannot use externally installed.


### PR DESCRIPTION
Fixes #524 

This probably won't pass CI until the repo is renamed to "htm.core".