### PR TITLE
SP fix global inhibition returns less than numDesired columns

### DIFF
--- a/src/examples/mnist/MNIST_SP.cpp
+++ b/src/examples/mnist/MNIST_SP.cpp
@@ -56,13 +56,13 @@ class MNIST {
 
 void setup() {
 
-  input.initialize({28 * 28});
-  columns.initialize({10 * 1000});
+  input.initialize({28, 28, 1});
+  columns.initialize({28, 28, 8});
   sp.initialize(
     /* inputDimensions */             input.dimensions,
     /* columnDimensions */            columns.dimensions,
-    /* potentialRadius */             999999u, // No topology, all to all connections.
-    /* potentialPct */                0.65f,
+    /* potentialRadius */             7u, // No topology, all to all connections.
+    /* potentialPct */                0.1f,
     /* globalInhibition */            true,
     /* localAreaDensity */            0.05f,  // % active bits
     /* numActiveColumnsPerInhArea */  -1,

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -395,7 +395,8 @@ void Connections::computeActivity(
     vector<SynapseIdx> &numActiveConnectedSynapsesForSegment,
     const vector<CellIdx> &activePresynapticCells)
 {
-  NTA_ASSERT(numActiveConnectedSynapsesForSegment.size() == segments_.size());
+  NTA_ASSERT(numActiveConnectedSynapsesForSegment.size() == segments_.size()) << "The output vector size must match "<< segments_.size();
+  NTA_ASSERT(activePresynapticCells.size() < segments_.size()) << "Input is larger than our number of segments!";
 
   if( timeseries_ ) {
     // Before each cycle of computation move the currentUpdates to the previous

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -392,11 +392,11 @@ public:
    * @param numActiveConnectedSynapsesForSegment
    * An output vector for active connected synapse counts per segment.
    *
-   * @param numActivePotentialSynapsesForSegment
+   * @param (optional) numActivePotentialSynapsesForSegment
    * An output vector for active potential synapse counts per segment.
    *
    * @param activePresynapticCells
-   * Active cells in the input.
+   * Active cells in the input as a sparse indices.
    */
   void computeActivity(std::vector<SynapseIdx> &numActiveConnectedSynapsesForSegment,
                        std::vector<SynapseIdx> &numActivePotentialSynapsesForSegment,

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -867,11 +867,10 @@ void SpatialPooler::inhibitColumnsGlobal_(const vector<Real> &overlaps,
                             << "for desired density (" << density << ").";
   // Sort the columns by the amount of overlap.  First make a list of all of the
   // column indexes.
-  activeColumns.reserve(numColumns_);
+  activeColumns.resize(numColumns_);
+  std::iota(activeColumns.begin(), activeColumns.end(), 0); //0,1,2,..,numColumns_-1
 
   int same_overlap = 0;
-  for(UInt i = 0; i < numColumns_; i++)
-    activeColumns.push_back(i);
   // Compare the column indexes by their overlap.
   auto compare = [&overlaps_, &same_overlap](const UInt &a, const UInt &b) -> bool
     {

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -847,10 +847,12 @@ void SpatialPooler::inhibitColumns_(const vector<Real> &overlaps,
   }
 }
 
+static int missed = 0;
+
 
 void SpatialPooler::inhibitColumnsGlobal_(const vector<Real> &overlaps,
-                                          Real density,
-                                          vector<UInt> &activeColumns) const {
+                                          const Real density,
+                                          SDR_sparse_t &activeColumns) const {
   NTA_ASSERT(!overlaps.empty());
   NTA_ASSERT(density > 0.0f && density <= 1.0f);
 
@@ -860,34 +862,55 @@ void SpatialPooler::inhibitColumnsGlobal_(const vector<Real> &overlaps,
     overlaps_[i] += tieBreaker_[i];
 
   activeColumns.clear();
-  const UInt numDesired = (UInt)(density * numColumns_);
+  const UInt numDesired = static_cast<UInt>(density*numColumns_);
   NTA_CHECK(numDesired > 0) << "Not enough columns (" << numColumns_ << ") "
                             << "for desired density (" << density << ").";
   // Sort the columns by the amount of overlap.  First make a list of all of the
   // column indexes.
   activeColumns.reserve(numColumns_);
+
+  int same_overlap = 0;
   for(UInt i = 0; i < numColumns_; i++)
     activeColumns.push_back(i);
   // Compare the column indexes by their overlap.
-  auto compare = [&overlaps_](const UInt &a, const UInt &b) -> bool
-    {return (overlaps_[a] == overlaps_[b]) ? a > b : overlaps_[a] > overlaps_[b];};
+  auto compare = [&overlaps_, &same_overlap](const UInt &a, const UInt &b) -> bool
+    {
+      if (overlaps_[a] == overlaps_[b]) {
+	same_overlap++;
+        return  a > b; //but we also need this for deterministic results
+      } else {
+        return overlaps_[a] > overlaps_[b]; //this is the main "sort columns by overlaps"
+      }
+    };
   // Do a partial sort to divide the winners from the losers.  This sort is
   // faster than a regular sort because it stops after it partitions the
   // elements about the Nth element, with all elements on their correct side of
   // the Nth element.
-  std::nth_element(
+/*  
+    std::nth_element(
     activeColumns.begin(),
     activeColumns.begin() + numDesired,
     activeColumns.end(),
     compare);
   // Remove the columns which lost the competition.
   activeColumns.resize(numDesired);
+  */
   // Finish sorting the winner columns by their overlap.
   std::sort(activeColumns.begin(), activeColumns.end(), compare);
   // Remove sub-threshold winners
   while( !activeColumns.empty() &&
          overlaps[activeColumns.back()] < stimulusThreshold_)
       activeColumns.pop_back();
+
+  activeColumns.resize(std::min(numDesired, (UInt)activeColumns.size()));
+
+  //FIXME not numDesired 
+  if(iterationNum_ > 1000) { //need time for learning
+    if(activeColumns.size() != numDesired) {
+      missed++;
+      cout << "missed " << missed << " by " << (numDesired - activeColumns.size()) << " of " << numDesired << " same "<< same_overlap << "\n";
+    }
+  }
 }
 
 

--- a/src/htm/algorithms/SpatialPooler.hpp
+++ b/src/htm/algorithms/SpatialPooler.hpp
@@ -943,7 +943,8 @@ public:
      @param activeColumns
      an int array containing the indices of the active columns.
   */
-  void inhibitColumnsGlobal_(const vector<Real> &overlaps, Real density,
+  void inhibitColumnsGlobal_(const vector<Real> &overlaps, 
+		             const Real density,
                              vector<UInt> &activeColumns) const;
 
   /**
@@ -972,7 +973,8 @@ public:
      @param activeColumns
      an int array containing the indices of the active columns.
   */
-  void inhibitColumnsLocal_(const vector<Real> &overlaps, Real density,
+  void inhibitColumnsLocal_(const vector<Real> &overlaps, 
+		            const Real density,
                             vector<UInt> &activeColumns) const;
 
   /**


### PR DESCRIPTION
Inhibition reduces the number of active columns. 
Global inhibition should return constant sparsity (translated to only numDesired columns survives the inhibition). 
This is almost never the case, even if we could, g inh returns fewer columns. 

This PR is just WIP now that debugs the problem, I'm looking for best way to fix it. 

Cropping to nth_element  (to numDesired) might be premature optimization, as after that we remove sub threshold, zero, etc columns. 

Some items to look into in this PR: 
- connections `computeActivity` returns only sparse array (removes zero overlaps) -- this might be nice optimization, as everywhere instead of iterating through 0..numColumns, we'd go << SDR.size
- the deterministic sort (section `if overlaps[a]==overlaps[b]: return a< b` removes duplicit entries. That is wrong, as 2 (or more) same overlaps are valid, and might be in the top n columns to keep. 
