### PR TITLE
Rename "nupic.cpp" to "htm.core" in obvious places.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The easiest way to contribute is to simply use this library and if you encounter
 
 ### Develop Nupic!
 If you'd like to develop this library itself, we have put together a list of tasks which don't require extensive knowledge of this library but nonetheless are important and need help.  Look for issues with the tag "newbie" which are a good starting point:
- * https://github.com/htm-community/nupic.cpp/labels/newbie
+ * https://github.com/htm-community/htm.core/labels/newbie
 
 ### Discuss Nupic!
 We are open to new ideas and would be happy to discuss them.  To start the conversation, open an issue and we can talk about it.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <img src="http://numenta.org/87b23beb8a4b7dea7d88099bfb28d182.svg" alt="NuPIC Logo" width=100/>
 
-# Community NuPIC.cpp repository (formerly [nupic.core](http://github.com/numenta/nupic.core))
+# htm.core
 
 [![Linux/OSX Build Status](https://travis-ci.org/htm-community/htm.core.svg?branch=master)](https://travis-ci.org/htm-community/htm.core)
 [![OSX CircleCI](https://circleci.com/gh/htm-community/htm.core/tree/master.svg?style=svg)](https://circleci.com/gh/htm-community/htm.core/tree/master)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/59f87and1x0ugss9/branch/master?svg=true)](https://ci.appveyor.com/project/htm-community/nupic-cpp/branch/master)
 
-This fork is a community version of the [nupic.core](https://github.com/numenta/nupic.core) C++ repository with Python bindings.
+This is a Community Fork of the [nupic.core](https://github.com/numenta/nupic.core) C++ repository, with Python bindings.
 
 ## Project Goals
 
-- Actively developed C++ core library for nupic.core (Numenta's repos are in maintenance mode only)
+- Actively developed C++ core library (Numenta's NuPIC repos are in maintenance mode only)
 - Clean, lean, optimized, and modern codebase
 - Stable and well tested code
 - Open and easier involvement of new ideas across HTM community (it's fun to contribute, we make master run stable, but are more open to experiments and larger revamps of the code if it proves useful).
@@ -42,7 +42,7 @@ in C++ library.
 
 ## Building from Source
 
-Fork or download the HTM-Community Nupic.cpp repository from https://github.com/htm-community/nupic.cpp
+Fork or download the HTM-Community htm.core repository from https://github.com/htm-community/htm.core
 
 ## Prerequisites
 
@@ -161,12 +161,12 @@ docker build --build-arg arch=arm64 .
 
 ### Linux auto build @ TravisCI
 
- * [Build](https://travis-ci.org/htm-community/nupic.cpp)
+ * [Build](https://travis-ci.org/htm-community/htm.core)
  * [Config](./.travis.yml)
 
 ### Mac OS/X auto build @ CircleCI
 
- * [Build](https://circleci.com/gh/htm-community/nupic.cpp/tree/master)
+ * [Build](https://circleci.com/gh/htm-community/htm.core/tree/master)
  * [Config](./.circleci/config.yml)
  * Local Test Build: `circleci local execute --job build-and-test`
 
@@ -179,7 +179,7 @@ docker build --build-arg arch=arm64 .
 
 This uses Docker and QEMU to achieve an ARM64 build on CircleCI's x86 hardware.
 
- * **TODO!** [Build]()
+ * [Build](https://circleci.com/gh/htm-community/htm.core/tree/master)
  * [Config](./.circleci/config.yml)
  * Local Test Build: `circleci local execute --job arm64-build-test`
 

--- a/startupMSVC.bat
+++ b/startupMSVC.bat
@@ -1,5 +1,5 @@
 @echo off
-rem // Runs CMake to configure Nupic.cpp for Visual Studio 2017
+rem // Runs CMake to configure htm.core for Visual Studio 2017
 rem // Execute this file to start up CMake and configure Visual Studio.
 rem //
 rem // There is no need to use Developer Command Prompt for running CMake with 


### PR DESCRIPTION
Rename "nupic.cpp" to "htm.core" in obvious places.
Fix TODO with working link.