### PR TITLE
Revert "SP measure time inh/overlaps/other in compute()"

### DIFF
--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -158,9 +158,6 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
       cout << "Init:\t" << tInit.getElapsed() << endl;
       cout << "Random:\t" << tRng.getElapsed() << endl;
       cout << "Encode:\t" << tEnc.getElapsed() << endl;
-      cout << "Inh " << spGlobal.tInh.getElapsed() << endl;
-      cout << "Overlaps " << spGlobal.tOverlap.getElapsed() << endl; 
-
       if(useSPlocal)  cout << "SP (l):\t" << tSPloc.getElapsed()*1.0f  << endl;
       if(useSPglobal) cout << "SP (g):\t" << tSPglob.getElapsed() << endl;
       if(useTM) cout << "TM:\t" << tTM.getElapsed() << endl;

--- a/src/examples/mnist/MNIST_SP.cpp
+++ b/src/examples/mnist/MNIST_SP.cpp
@@ -155,9 +155,7 @@ void train(const bool skipSP=false) {
   }
   
   tTrain.stop();
-  cout << "MNIST train time: " << tTrain.getElapsed() << endl;
-  cout << "inh " << sp.tInh.getElapsed() << endl;
-  cout << "over " << sp.tOverlap.getElapsed() << endl; 
+  cout << "MNIST train time: " << tTrain.getElapsed() << endl; 
 
   // Save the connections to file for postmortem analysis.
   ofstream dump("mnist_sp_learned.connections", ofstream::binary | ofstream::trunc | ofstream::out);

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -463,14 +463,10 @@ void SpatialPooler::compute(const SDR &input, const bool learn, SDR &active) {
   input.reshape(  inputDimensions_ );
   active.reshape( columnDimensions_ );
   updateBookeepingVars_(learn);
-
-  tOverlap.start();
   calculateOverlap_(input, overlaps_);
-  tOverlap.stop();
 
   boostOverlaps_(overlaps_, boostedOverlaps_);
 
-  tInh.start();
   auto &activeVector = active.getSparse();
   inhibitColumns_(boostedOverlaps_, activeVector);
   // Notify the active SDR that its internal data vector has changed.  Always
@@ -478,7 +474,6 @@ void SpatialPooler::compute(const SDR &input, const bool learn, SDR &active) {
   // inplace.
   sort( activeVector.begin(), activeVector.end() );
   active.setSparse( activeVector );
-  tInh.stop();
 
   if (learn) {
     adaptSynapses_(input, active);

--- a/src/htm/algorithms/SpatialPooler.hpp
+++ b/src/htm/algorithms/SpatialPooler.hpp
@@ -29,7 +29,7 @@
 #include <htm/types/Types.hpp>
 #include <htm/types/Serializable.hpp>
 #include <htm/types/Sdr.hpp>
-#include <htm/os/Timer.hpp> 
+
 
 namespace htm {
 
@@ -61,7 +61,6 @@ using namespace std;
 class SpatialPooler : public Serializable
 {
 public:
-  Timer tInh, tOverlap;
 
   const Real MAX_LOCALAREADENSITY = 0.5f; //require atleast 2 areas
 


### PR DESCRIPTION
Cleanup, just reverts debug timers. 

This reverts commit f164ea8c66c1b64b4823fb5d2387cd761449cebb.