### PR TITLE
Fixed particle swarming optimization

### DIFF
--- a/py/htm/examples/mnist.py
+++ b/py/htm/examples/mnist.py
@@ -149,8 +149,8 @@ def main(parameters=default_parameters, argv=None, verbose=True):
     score = score / len(test_data)
 
     print('Score:', 100 * score, '%')
-    return score < 0.95
+    return score
 
 
 if __name__ == '__main__':
-    sys.exit( main() )
+    sys.exit( main() < 0.95 )

--- a/py/htm/examples/mnist.py
+++ b/py/htm/examples/mnist.py
@@ -81,7 +81,7 @@ def load_mnist(path):
 default_parameters = {
     'potentialRadius': 7,
     'boostStrength': 7.0,
-    'columnDimensions': (28*28*8, 1),
+    'columnDimensions': (79, 79),
     'dutyCyclePeriod': 1402,
     'localAreaDensity': 0.1,
     'minPctOverlapDutyCycle': 0.2,


### PR DESCRIPTION
Added a mutex lock to the ParticleData so that it does not get corrupted
by being evaluated twice at the same time.  Because the optimizer always
runs from the main thread, it uses a simple flag (instead of a
thread safe mutex).

Also fixed the python MNIST example.  Now it works with the optimization
framework, and also returns a good value for CI to use.