### PR TITLE
Connections: apply synapsesCompetition() in adaptSegment()

### DIFF
--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -475,6 +475,9 @@ void Connections::adaptSegment(const Segment segment,
     }
   }
 
+  //balance synapses using competition on dendrite
+  synapseCompetition(segment, 4, 10); //FIXME derive these numbers
+
   //destroy segment if it has too few synapses left -> will never be able to connect again
   if(pruneZeroSynapses and synapses.size() < connectedThreshold_) {
     destroySegment(segment);
@@ -545,7 +548,8 @@ void Connections::synapseCompetition(
                     const SynapseIdx maximumSynapses)
 {
   NTA_ASSERT( minimumSynapses <= maximumSynapses);
-  NTA_ASSERT( maximumSynapses > 0 );
+  NTA_ASSERT( maximumSynapses >= connectedThreshold );
+  NTA_ASSERT( minimumSynapses <  connectedThreshold );
 
   const auto &segData = dataForSegment( segment );
 
@@ -570,7 +574,7 @@ void Connections::synapseCompetition(
   // Can't connect more synapses than there are in the potential pool.
   desiredConnected = std::min( (SynapseIdx) segData.synapses.size(), desiredConnected);
   // The N'th synapse is at index N-1
-  if( desiredConnected != 0 ) {
+  if( desiredConnected > 0 ) {
     desiredConnected--;
   }
   // else {

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -53,8 +53,6 @@ void Connections::initialize(CellIdx numCells, Permanence connectedThreshold, bo
   connectedThreshold_ = connectedThreshold - htm::Epsilon;
   iteration_ = 0;
 
-  rng_ = Random(42); //TODO set the seed
-
   nextEventToken_ = 0;
 
   timeseries_ = timeseries;
@@ -478,8 +476,7 @@ void Connections::adaptSegment(const Segment segment,
   }
 
   //balance synapses using competition on dendrite
-  if(rng_.getReal64() < 0.01f) //1% chance //TODO set the probability?
-    synapseCompetition(segment, 4, 10); //FIXME derive these numbers
+  synapseCompetition(segment, 4, 10); //FIXME derive these numbers
 
   //destroy segment if it has too few synapses left -> will never be able to connect again
   if(pruneZeroSynapses and synapses.size() < connectedThreshold_) {

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -250,18 +250,14 @@ void Connections::destroySynapse(const Synapse synapse) {
     }
   }
 
-  const auto synapseOnSegment =
-      std::lower_bound(segmentData.synapses.cbegin(), segmentData.synapses.cend(),
-                       synapse, 
-		       [&](const Synapse a, const Synapse b) -> bool {
-			 return dataForSynapse(a).id < dataForSynapse(b).id;
-                       });
+  const auto synapseOnSegment = std::find(segmentData.synapses.cbegin(), 
+		                          segmentData.synapses.cend(),
+					  synapse);
 
-  NTA_ASSERT(synapseOnSegment != segmentData.synapses.end());
+  NTA_ASSERT(synapseOnSegment != segmentData.synapses.cend());
   NTA_ASSERT(*synapseOnSegment == synapse);
 
   segmentData.synapses.erase(synapseOnSegment);
-
   destroyedSynapses_.push_back(synapse);
 }
 
@@ -348,7 +344,7 @@ bool Connections::compareSegments(const Segment a, const Segment b) const {
   // default sort by cell
   if (aData.cell == bData.cell)
     //fallback to ordinals:
-    return aData.id < bData.id;
+    return aData.id < bData.id; //TODO is segment's id/ordinals needed?
   else return aData.cell < bData.cell;
 }
 

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -53,6 +53,8 @@ void Connections::initialize(CellIdx numCells, Permanence connectedThreshold, bo
   connectedThreshold_ = connectedThreshold - htm::Epsilon;
   iteration_ = 0;
 
+  rng_ = Random(42); //TODO set the seed
+
   nextEventToken_ = 0;
 
   timeseries_ = timeseries;
@@ -476,7 +478,8 @@ void Connections::adaptSegment(const Segment segment,
   }
 
   //balance synapses using competition on dendrite
-  synapseCompetition(segment, 4, 10); //FIXME derive these numbers
+  if(rng_.getReal64() < 0.01f) //1% chance //TODO set the probability?
+    synapseCompetition(segment, 4, 10); //FIXME derive these numbers
 
   //destroy segment if it has too few synapses left -> will never be able to connect again
   if(pruneZeroSynapses and synapses.size() < connectedThreshold_) {

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -33,6 +33,7 @@
 #include <htm/types/Types.hpp>
 #include <htm/types/Serializable.hpp>
 #include <htm/types/Sdr.hpp>
+#include <htm/utils/Random.hpp>
 
 namespace htm {
 
@@ -715,9 +716,9 @@ private:
   std::vector<Synapse>     destroyedSynapses_;
   Permanence               connectedThreshold_; //TODO make const
   UInt32 iteration_ = 0;
+  Random rng_;
 
   // Extra bookkeeping for faster computing of segment activity.
- 
   struct identity { constexpr size_t operator()( const CellIdx t ) const noexcept { return t; };   };	//TODO in c++20 use std::identity 
 
   std::unordered_map<CellIdx, std::vector<Synapse>, identity> potentialSynapsesForPresynapticCell_;

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -510,7 +510,7 @@ public:
    */
   void synapseCompetition(  const Segment    segment,
                             const SynapseIdx minimumSynapses,
-                            const SynapseIdx maximumSynapses);
+                            const SynapseIdx maximumSynapses); 
 
 
   /**

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -33,7 +33,6 @@
 #include <htm/types/Types.hpp>
 #include <htm/types/Serializable.hpp>
 #include <htm/types/Sdr.hpp>
-#include <htm/utils/Random.hpp>
 
 namespace htm {
 
@@ -716,9 +715,9 @@ private:
   std::vector<Synapse>     destroyedSynapses_;
   Permanence               connectedThreshold_; //TODO make const
   UInt32 iteration_ = 0;
-  Random rng_;
 
   // Extra bookkeeping for faster computing of segment activity.
+ 
   struct identity { constexpr size_t operator()( const CellIdx t ) const noexcept { return t; };   };	//TODO in c++20 use std::identity 
 
   std::unordered_map<CellIdx, std::vector<Synapse>, identity> potentialSynapsesForPresynapticCell_;

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -702,7 +702,7 @@ Real SpatialPooler::avgConnectedSpanForColumnND_(UInt column) const {
 void SpatialPooler::adaptSynapses_(const SDR &input,
                                    const SDR &active) {
   for(const auto &column : active.getSparse()) {
-    connections_.adaptSegment(column, input, synPermActiveInc_, synPermInactiveDec_);
+    connections_.adaptSegment(column, input, synPermActiveInc_, synPermInactiveDec_, true);
     connections_.raisePermanencesToThreshold( column, stimulusThreshold_ );
   }
 }


### PR DESCRIPTION
- [x] SP uses synapse pruning, same as TM has been doing
  - [ ] make pruning default to true in adaptSegment (unless it breaks too many tests)
  - or altogether remove the param and just use it? 
  - this brings a performance gain about 5%
- [ ] WIP `Connections.adaptSegment`  calls newly added `synapsesCompetition`
- [ ] tests expected to fail with mismatches

Follow up to #466 
Fixes #558 