### PR TITLE
Spatial anomaly

### DIFF
--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -459,7 +459,11 @@ void SpatialPooler::initialize(
 }
 
 
-void SpatialPooler::compute(const SDR &input, const bool learn, SDR &active) {
+void SpatialPooler::compute(const SDR &input, 
+		            const bool learn, 
+			    SDR &active,
+			    const Real spatialAnomalyInputValue) {
+
   input.reshape(  inputDimensions_ );
   active.reshape( columnDimensions_ );
   updateBookeepingVars_(learn);
@@ -484,6 +488,11 @@ void SpatialPooler::compute(const SDR &input, const bool learn, SDR &active) {
       updateInhibitionRadius_();
       updateMinDutyCycles_();
     }
+  }
+
+  //update spatial anomaly
+  if(this->spAnomaly.enabled) {
+    spAnomaly.compute(spatialAnomalyInputValue);
   }
 }
 


### PR DESCRIPTION
- [x] implements spatial anomaly, as is currenly used in NAB
  - use as `SP.anomaly&`
  - [ ] later find better approach, but not part of this PR
- [x] test & doc
- [ ] bindings - I'm waiting with bindings for consulting with you, 
  - I don't like extending `SP.compute(..., Real spatialValue)` with the optional argument for spatial anomaly (it designates the original input value)
  - [ ] my proposal: Extend SDR to have `const Real& SDR.origValue` 
    - which the encoder, user on input sets
    - other layers copy to higher SDRs (enc->SP->TM) still carries the same value. 
    - used by: Predictor, Classifier, spatial_anomaly
    - can be unknown (default) (merging in higher layers, ...) 