### PR TITLE
TM anomaly: new modes: likelihood,...

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -47,6 +47,13 @@ Example usage:
     TODO
 )");
 
+	py::enum_<TemporalMemory::ANMode>(m, "ANMode")
+	  .value("DISABLED",   TemporalMemory::ANMode::DISABLED)
+	  .value("RAW",        TemporalMemory::ANMode::RAW)
+	  .value("LIKELIHOOD", TemporalMemory::ANMode::LIKELIHOOD)
+	  .value("LOGLIKELIHOOD", TemporalMemory::ANMode::LOGLIKELIHOOD)
+	  .export_values();
+
         py_HTM.def(py::init<>());
         py_HTM.def(py::init<std::vector<CellIdx>
                 , CellIdx
@@ -62,7 +69,8 @@ Example usage:
                 , SegmentIdx
                 , SynapseIdx
                 , bool
-                , UInt>(),
+                , UInt
+		, TemporalMemory::ANMode>(),
 R"(Initialize the temporal memory (TM) using the given parameters.
 
 Argument columnDimensions
@@ -123,6 +131,10 @@ Argument externalPredictiveInputs
     TemporalMemory.  If this is given (and greater than 0) then the active
     cells and winner cells of these external inputs must be given to methods
     TM.compute and TM.activateDendrites
+
+Argument anomalyMode (optional, default ANMode::RAW) selects mode for `TM.anomaly`.
+    Options are ANMode {DISABLED, RAW, LIKELIHOOD, LOGLIKELIHOOD}
+
 )"
                 , py::arg("columnDimensions")
                 , py::arg("cellsPerColumn") = 32
@@ -139,7 +151,8 @@ Argument externalPredictiveInputs
                 , py::arg("maxSynapsesPerSegment") = 255
                 , py::arg("checkInputs") = true
                 , py::arg("externalPredictiveInputs") = 0u
-            );
+		, py::arg("anomalyMode") = TemporalMemory::ANMode::RAW 
+		);
 
         py_HTM.def("printParameters",
             [](const HTM_t& self)

--- a/src/htm/algorithms/AnomalyLikelihood.cpp
+++ b/src/htm/algorithms/AnomalyLikelihood.cpp
@@ -27,6 +27,7 @@ AnomalyLikelihood::AnomalyLikelihood(UInt learningPeriod, UInt estimationSamples
         iteration_ = 0;
         NTA_CHECK(historicWindowSize >= estimationSamples); // cerr << "estimationSamples exceeds historicWindowSize";
         NTA_CHECK(aggregationWindow < reestimationPeriod && reestimationPeriod < historicWindowSize);
+	NTA_WARN << "C++ AnomalyLikelihood may still need some testing.";
     }
 
 

--- a/src/htm/algorithms/TemporalMemory.cpp
+++ b/src/htm/algorithms/TemporalMemory.cpp
@@ -533,44 +533,38 @@ void TemporalMemory::compute(const SDR &activeColumns,
   // Must be computed here, between `activateDendrites()` and `activateCells()`.
   switch(tmAnomaly_.mode_) {
 
-    case ANMode::DISABLED:
-      break;
+    case ANMode::DISABLED: {
+      tmAnomaly_.anomaly_ = 0.5f; 
+			   } break;
 
-    case ANMode::RAW:
+    case ANMode::RAW: {
       tmAnomaly_.anomaly_ = computeRawAnomalyScore(
                              activeColumns,
                              cellsToColumns( getPredictiveCells() ));
-      break; 
+		      } break;
 
-    case ANMode::LIKELIHOOD:
-      {
-      const Real raww = computeRawAnomalyScore(
+    case ANMode::LIKELIHOOD: {
+      const Real raw = computeRawAnomalyScore(
                          activeColumns,
                          cellsToColumns( getPredictiveCells() ));
-      tmAnomaly_.anomaly_ = tmAnomaly_.anomalyLikelihood_.anomalyProbability(raww);
-      }
-      break;
+      tmAnomaly_.anomaly_ = tmAnomaly_.anomalyLikelihood_.anomalyProbability(raw);
+			     } break;
 
-    case ANMode::LOGLIKELIHOOD:
-      {
+    case ANMode::LOGLIKELIHOOD: {
       const Real raw = computeRawAnomalyScore(
                          activeColumns,
                          cellsToColumns( getPredictiveCells() ));
       const Real like = tmAnomaly_.anomalyLikelihood_.anomalyProbability(raw);
       const Real log  = tmAnomaly_.anomalyLikelihood_.computeLogLikelihood(like);
       tmAnomaly_.anomaly_ = log;
-      }
-      break;
-
-    default:
-      NTA_THROW << "TM.anomaly got unknown mode during computation ";
-
+				} break;
   // TODO: Update mean & standard deviation of anomaly here.
-  }
-  NTA_ASSERT(tmAnomaly_.anomaly >= 0.0f and tmAnomaly_.anomaly <= 1.0f) << "TM.anomaly is out-of-bounds!";
+  };
+  NTA_ASSERT(tmAnomaly_.anomaly_ >= 0.0f and tmAnomaly_.anomaly_ <= 1.0f) << "TM.anomaly is out-of-bounds!";
 
   activateCells(activeColumns, learn);
 }
+
 
 void TemporalMemory::compute(const SDR &activeColumns, const bool learn) {
   SDR externalPredictiveInputsActive({ externalPredictiveInputs_ });
@@ -793,7 +787,7 @@ bool TemporalMemory::operator==(const TemporalMemory &other) const {
       winnerCells_ != other.winnerCells_ ||
       maxSegmentsPerCell_ != other.maxSegmentsPerCell_ ||
       maxSynapsesPerSegment_ != other.maxSynapsesPerSegment_ ||
-      tmAnomaly_.anomaly != other.tmAnomaly_.anomaly ||
+      tmAnomaly_.anomaly_ != other.tmAnomaly_.anomaly_ ||
       tmAnomaly_.mode_ != other.tmAnomaly_.mode_ || 
       tmAnomaly_.anomalyLikelihood_ != other.tmAnomaly_.anomalyLikelihood_ ) {
     return false;

--- a/src/htm/algorithms/TemporalMemory.cpp
+++ b/src/htm/algorithms/TemporalMemory.cpp
@@ -547,7 +547,7 @@ void TemporalMemory::compute(const SDR &activeColumns,
       const Real raww = computeRawAnomalyScore(
                          activeColumns,
                          cellsToColumns( getPredictiveCells() ));
-      tmAnomaly_.anomaly_ = anomalyLikelihood.anomalyProbability(raww);
+      tmAnomaly_.anomaly_ = tmAnomaly_.anomalyLikelihood_.anomalyProbability(raww);
       }
       break;
 
@@ -556,8 +556,8 @@ void TemporalMemory::compute(const SDR &activeColumns,
       const Real raw = computeRawAnomalyScore(
                          activeColumns,
                          cellsToColumns( getPredictiveCells() ));
-      const Real like = anomalyLikelihood.anomalyProbability(raw);
-      const Real log  = anomalyLikelihood.computeLogLikelihood(like);
+      const Real like = tmAnomaly_.anomalyLikelihood_.anomalyProbability(raw);
+      const Real log  = tmAnomaly_.anomalyLikelihood_.computeLogLikelihood(like);
       tmAnomaly_.anomaly_ = log;
       }
       break;
@@ -584,7 +584,7 @@ void TemporalMemory::reset(void) {
   activeSegments_.clear();
   matchingSegments_.clear();
   segmentsValid_ = false;
-  tmAnomaly_.anomaly_ = 0.5f;
+  tmAnomaly_.anomaly_ = -1.0f; //TODO reset rather to 0.5 as default (undecided) anomaly
 }
 
 // ==============================
@@ -795,7 +795,7 @@ bool TemporalMemory::operator==(const TemporalMemory &other) const {
       maxSynapsesPerSegment_ != other.maxSynapsesPerSegment_ ||
       tmAnomaly_.anomaly != other.tmAnomaly_.anomaly ||
       tmAnomaly_.mode_ != other.tmAnomaly_.mode_ || 
-      anomalyLikelihood != other.anomalyLikelihood ) {
+      tmAnomaly_.anomalyLikelihood_ != other.tmAnomaly_.anomalyLikelihood_ ) {
     return false;
   }
 

--- a/src/htm/algorithms/TemporalMemory.hpp
+++ b/src/htm/algorithms/TemporalMemory.hpp
@@ -480,6 +480,7 @@ public:
        CEREAL_NVP(segmentsValid_),
        CEREAL_NVP(tmAnomaly_.anomaly_),
        CEREAL_NVP(tmAnomaly_.mode_),
+       CEREAL_NVP(tmAnomaly_.anomalyLikelihood_),
        CEREAL_NVP(connections));
 
     cereal::size_type numActiveSegments = activeSegments_.size();
@@ -536,6 +537,7 @@ public:
        CEREAL_NVP(segmentsValid_),
        CEREAL_NVP(tmAnomaly_.anomaly_),
        CEREAL_NVP(tmAnomaly_.mode_),
+       CEREAL_NVP(tmAnomaly_.anomalyLikelihood_),
        CEREAL_NVP(connections));
 
     numActiveConnectedSynapsesForSegment_.assign(connections.segmentFlatListLength(), 0);
@@ -639,7 +641,6 @@ private:
   vector<SynapseIdx> numActivePotentialSynapsesForSegment_;
 
   Random rng_;
-  AnomalyLikelihood anomalyLikelihood;
 
 public:
   Connections connections;
@@ -660,6 +661,7 @@ public:
       friend class TemporalMemory;
       Real anomaly_ = 0.5f; //default value
       ANMode mode_ = ANMode::RAW;
+      AnomalyLikelihood anomalyLikelihood_; //TODO provide default/customizable params here
   } tmAnomaly_;
 
 };

--- a/src/htm/algorithms/TemporalMemory.hpp
+++ b/src/htm/algorithms/TemporalMemory.hpp
@@ -37,6 +37,7 @@ namespace htm {
 using namespace std;
 using namespace htm;
 
+
 /**
  * Temporal Memory implementation in C++.
  *
@@ -241,6 +242,10 @@ public:
    * This method calls activateDendrites, then calls activateCells. Using
    * the TemporalMemory via its compute method ensures that you'll always
    * be able to call getActiveCells at the end of the time step.
+   *
+   * Additionaly, this method computes anomaly for `TM.anomaly&`, if you
+   * use other learning methods (activateCells(), activateDendrites()) your
+   * anomaly scores will be off. 
    *
    * @param activeColumns
    * Sorted SDR of active columns.
@@ -642,10 +647,22 @@ private:
 
   Random rng_;
 
+  /**
+   * holds logic and data for TM's anomaly
+   */
+  struct anomaly_tm {
+    protected:
+      friend class TemporalMemory;
+      Real anomaly_ = 0.5f; //default value
+      ANMode mode_ = ANMode::RAW;
+      AnomalyLikelihood anomalyLikelihood_; //TODO provide default/customizable params here
+  };
+
 public:
   Connections connections;
   const UInt &externalPredictiveInputs = externalPredictiveInputs_;
 
+  anomaly_tm tmAnomaly_;
   /*
    *  anomaly score computed for the current inputs
    *  (auto-updates after each call to TM::compute())
@@ -653,16 +670,8 @@ public:
    *  @return a float value from computeRawAnomalyScore()
    *  from Anomaly.hpp
    */
-  const Real &anomaly = tmAnomaly_.anomaly;
-  struct anomaly_tm {
-    const Real& anomaly = anomaly_;
-
-    protected:
-      friend class TemporalMemory;
-      Real anomaly_ = 0.5f; //default value
-      ANMode mode_ = ANMode::RAW;
-      AnomalyLikelihood anomalyLikelihood_; //TODO provide default/customizable params here
-  } tmAnomaly_;
+const Real &anomaly = tmAnomaly_.anomaly_; //this is position dependant, the struct anomaly_tm must be defined before this use,
+// otherwise this surprisingly compiles, but a call to `tmAnomaly_.anomaly` segfaults!
 
 };
 

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -70,10 +70,11 @@ float runTemporalMemoryTest(UInt numColumns, UInt w,   int numSequences, //TODO 
 
   // learn
   for (int i = 0; i < 5; i++) {
-    for (auto sequence : sequences) {
-      for (auto sdr : sequence) {
+    for (const auto& sequence : sequences) {
+      for (const auto& sdr : sequence) {
         tm.compute(sdr, true);
-	avgAnomAfter = anom10.compute(tm.anomaly); //average anomaly score
+	const Real an = tm.anomaly;
+	avgAnomAfter = anom10.compute(an); //average anomaly score
       }
       tm.reset();
     }


### PR DESCRIPTION
For #469 , and https://github.com/htm-community/NAB/pull/5 

- [x] implement other modes for `TM.anomaly`
  - `ANMode {DISABLED, RAW, LIKELIHOOD, LOGLIKELIHOOD}`
  - this is using the not 100% validated c++ Likelihood, but provides convenient API to use it within TM,
    and aims to replace code in NAB HTMcore detector
- [x] bidings
- [x] still some bug which segfaults