### PR TITLE
Do not require operator== for region implementation.

### DIFF
--- a/src/htm/engine/RegionImpl.hpp
+++ b/src/htm/engine/RegionImpl.hpp
@@ -218,7 +218,11 @@ public:
   virtual void cereal_adapter_save(ArWrapper& a) const {};
   virtual void cereal_adapter_load(ArWrapper& a) {};
 
-  virtual bool operator==(const RegionImpl &other) const = 0;
+  // NOTE: all internal regions must implement an override of operator== by convention for unit testing.  
+  //            Customer written regions do not require it.
+  virtual bool operator==(const RegionImpl &other) const { 
+    NTA_THROW << "operator== not implmented for region "+getName(); 
+  };
   virtual inline bool operator!=(const RegionImpl &other) const {
     return !operator==(other);
   }

--- a/src/test/unit/regions/SPRegionTest.cpp
+++ b/src/test/unit/regions/SPRegionTest.cpp
@@ -353,7 +353,7 @@ TEST(SPRegionTest, testSerialization)
 
 	  // Change some parameters and see if they are retained after a restore.
     n2region2->setParameterBool("globalInhibition", true);
-    n2region2->setParameterReal32("localAreaDensity", 0.23);
+    n2region2->setParameterReal32("localAreaDensity", 0.23f);
     n2region2->setParameterReal32("potentialPct", 0.85f);
     n2region2->setParameterReal32("synPermActiveInc", 0.04f);
     n2region2->setParameterReal32("synPermInactiveDec", 0.005f);


### PR DESCRIPTION
 Allow users to implement regions without …an operator==( ) function.

See issue #592