### PR TITLE
Remove the rounding in line 257

### DIFF
--- a/py/htm/encoders/date.py
+++ b/py/htm/encoders/date.py
@@ -254,7 +254,7 @@ class DateEncoder:
 
     if self.dayOfWeekEncoder is not None:
       dayOfWeek = timetuple.tm_wday + (timeOfDay) / 24.0
-      dayOfWeek -= .5 # Round towards noon, not midnight
+      # dayOfWeek -= .5 # Round towards noon, not midnight | Throws an error for monday at midnight
       sdrs.append( self.dayOfWeekEncoder.encode(dayOfWeek) )
 
     if self.weekendEncoder is not None:


### PR DESCRIPTION
If the time is 00:00:000 and the day of the week is a Monday, e.g 0, then when the date is encoded you will have a negative value i.e (-0.5), which causes the encoder to fail.
A TODO item might be to check the values of the time and if they are OK allow for this rounding. But i saw the similar solution in 252 to just comment it out for now