### PR TITLE
Python2 should still be supported

### DIFF
--- a/bindings/py/packaging/setup.py
+++ b/bindings/py/packaging/setup.py
@@ -355,6 +355,7 @@ if __name__ == "__main__":
     license = "GNU Affero General Public License v3 or later (AGPLv3+)",
     classifiers=[
       "Programming Language :: Python",
+      "Programming Language :: Python :: 2",
       "Programming Language :: Python :: 3",
       "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
       "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
otherwise setup.py does not build under py2