### PR TITLE
Deployment where each CI uploads its own artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ jobs:
             python setup.py bdist_wheel
             cd build/scripts
             make package
+            # save artifacts so you can see them with circleCI web site
             mkdir -p /tmp/uploads
             cp -a *.tar.gz /tmp/uploads
 
@@ -142,25 +143,70 @@ jobs:
       - store_artifacts:
           path: /tmp/uploads
 
-      ##- persist_to_workspace:
-      ##    root: dist
-      ##    paths:
-      ##    - htm.bindings*.whl
-      ##    - requirements.txt
-      ##    - include/htm
-            #  deploy-s3:
-            #machine: true
-            #steps:
-            #- attach_workspace:
-            #at: dist
-            #- run:
-            #name: Deploying to S3
-            #command: |
-            #pip install awscli --upgrade --user
-            #tar -zcv -f htm_core-${CIRCLE_SHA1}-darwin64.tar.gz dist
-            #aws s3 cp htm_core-${CIRCLE_SHA1}-darwin64.tar.gz s3://artifacts.numenta.org/numenta/htm.core/circle/
+      # keep the artifacts around for the osx-deploy job
+      # in case this is a tagged master build.
+      - persist_to_workspace:
+          root: build/scripts
+          paths: *.tar.gz
+
+  # job: Mac OS/X tagged master, deply to GitHub Releases
+  #
+  # This will need a GitHub Deploy key with write permissions $GITHUB_TOKEN
+  # See https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-deploy-key
+  #
+  osx-deploy-github:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - attach_workspace:
+          at: ./build/scripts
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            go get github.com/itchio/gothub
+            echo "Release version: $CIRCLE_TAG"
+            
+            cd build/scripts
+            for file in ./*.tar.gz ; do
+              if [ -e "$file" ] ; then  # check if file exists.
+                 export GITHUB_USER="htm-community"
+                 export GITHUB_REPO="htm.core"
+                 gothub upload --tag $CIRCLE_TAG --name "$file" --file "$file" --replace 
+              fi
+            done
 
 
+  # job: Mac OS/X tagged master, deply to GitHub Releases and PYPI
+  # https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/?gclid=Cj0KCQjwwIPrBRCJARIsAFlVT8-k1HNsdMJnCg3waIhxjgVOdcGEerQviERJm5qUnQNWppPGOIhgnNQaAk21EALw_wcB
+  # Note: uses $PYPI_PASSWORD 
+  #
+  osx-deploy-pypi:
+    docker:
+      - image: circleci/python:3.6.4 
+    steps:
+      - attach_workspace:
+          at: ./build/scripts
+      - run:
+          name: "Publish Release on PYPI"
+          command: |
+            python3 -m pip install twine
+            cd build/scripts
+            mkdir artifact
+            for file in ./*.tar.gz ; do
+              if [ -e "$file" ] ; then  # check if file exists.
+                 # extract the wheel from the github package
+                 cd artifact
+                 tar -xf ../$file
+                 cp */py/*.whl ..
+                 cd ..
+               fi
+             done
+             export TWINE_REPOSITORY_URL = "https://test.pypi.org/legacy/"  # test server
+             export TWINE_USERNAME="__token__"   # token for PYPI test account for David Keeney.  Not for production
+             export TWINE_PASSWORD="pypi-AgENdGVzdC5weXBpLm9yZwIkOTk0YmZjNGYtZTgxNS00Yjk2LTg5ZTAtODE1MGI4MjZhNGZlAAIleyJwZXJtaXNzaW9ucyI6ICJ1c2VyIiwgInZlcnNpb24iOiAxfQAABiDXJOuxvodsEDoD5dOH-e0td1DdUSwrl2NCl_lP_vy6RA"
+             twine upload --skip-existing --verbose ./*.whl
+
+            
 
 
 
@@ -196,13 +242,30 @@ jobs:
 workflows:
   version: 2
 
-  osx-build-test-deploy: #runs on each commit
+  osx-build-test: #runs on each commit
     jobs:
       - osx-build-debug    # Mac OS/X raw ("build-debug")
       - osx-build-release:  # Mac OS/X raw ("build-release")
-          requires:
-            - osx-build-debug # all C++ debug tests must pass before Release (and thus artifact) is created
+          #requires:
+          #  - osx-build-debug # all C++ debug tests must pass before Release (and thus artifact) is created
 
+      - osx-deploy-github
+          requires:
+            - osx-build-release
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /v.*/
+              
+      - osx-deploy-pypi
+          requires:
+            - osx-build-release
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /v.*/
 
   nightly: # build and tests taking long time (currecntly ARM64 build ~5hrs), runs only once a day
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       # in case this is a tagged master build.
       - persist_to_workspace:
           root: build/scripts
-          paths: *.tar.gz
+          paths: "*.tar.gz"
 
   # job: Mac OS/X tagged master, deply to GitHub Releases
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,11 +245,11 @@ workflows:
   osx-build-test: #runs on each commit
     jobs:
       - osx-build-debug    # Mac OS/X raw ("build-debug")
-      - osx-build-release:  # Mac OS/X raw ("build-release")
+      - osx-build-release  # Mac OS/X raw ("build-release")
           #requires:
           #  - osx-build-debug # all C++ debug tests must pass before Release (and thus artifact) is created
 
-      - osx-deploy-github
+      - osx-deploy-github:
           requires:
             - osx-build-release
           filters:
@@ -258,7 +258,7 @@ workflows:
             tags:
               only: /v.*/
               
-      - osx-deploy-pypi
+      - osx-deploy-pypi:
           requires:
             - osx-build-release
           filters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_deploy:
   - cd $TRAVIS_BUILD_DIR/build/scripts
   - echo "  Build the GitHub Package"
   - make package
-  - ../../ci/fetch-artifacts.sh
+  #- ../../ci/fetch-artifacts.sh
 
 
 deploy:
@@ -76,9 +76,9 @@ deploy:
   provider: releases
   api_key: "$GITHUB_TOKEN"
   file_glob: true # allows '*' in file below
-  file: "$TRAVIS_BUILD_DIR/build/scripts/*.{tar.gz,zip}"
+  file: "build/scripts/*.tar.gz"
   skip_cleanup: true
-  name: "testing" # GH Release name, undocumented option
+  overwrite: true
   on:
     tags: true #GH requires tagged release
     branch: master
@@ -95,7 +95,7 @@ deploy:
     repo: htm-community/htm.core
   distributions: "bdist_wheel"
   file_glob: true # allows '*' in file below
-  file: "$TRAVIS_BUILD_DIR/build/scripts/*.whl"
+  file: "build/Release/distr/dist/*.whl"
   skip_existing: true
   skip_cleanup: true
      

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,16 +152,16 @@ deploy:
     ## Deploy to GitHub Releases
     ## see https://www.appveyor.com/docs/deployment/github/
     ##
-   release: 'htm.core' #htmcore-win64-v$(appveyor_build_version)
-      description: 'HTM.core binary release '
-      provider: GitHub
-      auth_token: 
+    release: 'htm.core' #htmcore-win64-v$(appveyor_build_version)
+    description: 'HTM.core binary release '
+    provider: GitHub
+    auth_token: 
         secure: "%GITHUB_TOKEN%"
-      artifact: 'build\scripts\*.zip' # upload .zip from 'make package'
-      draft: false
-      prerelease: false
-      force_update: true #override files in existing release
-      on:
+    artifact: 'build\scripts\*.zip' # upload .zip from 'make package'
+    draft: false
+    prerelease: false
+    force_update: true #override files in existing release
+    on:
         branch: master                # release from master branch only
         appveyor_repo_tag: true       # deploy on tag push only
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,11 +50,9 @@ environment:
   ARTIFACTS_DIR: "%HTM_CORE%\\build\\artifacts"
   configuration: "Release"
   GITHUB_TOKEN: "fX0sRFrScPzNxDgmzcihMg3m42f85w4SFKN9T2Ezq/xUrYEBGaOWAWUANj+564JS8J/WwAVWZJctAp7sUaMMEaFqcDaY9US+megZJraX2C45BmgDaGQcKHIUjrXV39gizt2jCxBXTxUxafskKF1nx93SZkKuRmy2znFt1ewFooRJisl+IEnaGqtCtqt7TLq6lRw0rYGpX94VXhapk8izv4awjjUDR2KEZu4rcBcU+Xbpi9QWLR2qLEdcShZI++M/KU7STAjTzPgcADReVnL09nd99VnhPTwYIkPau22Q3+YUpcyxho9A522ZbYkgWCBAiIqFA9X1E8XsVXJ/p2Q17cQtNu97GkKerltlioxZFy9ck1533CNew3nXd8CprMQQd4uL5rCX3C6rhdossKpKmAkUSnzuh7Duy/emzy1jGEBkQagX1YBbFxkSUaQbDL+RHW89KFiU7C/WOsoauAc3twpNB/cJbdV4V/r/9SeenCOc1KGwMt61pbpAb6Gn0B51etqYvUnAE8ZQs3qB8+cqHn85Ej6P7XzuuMICrsNj2vNvtP+frz7KICmgLTf9TzkgBEzd60YhgD1tldcT9N7+FeiAeaeGIao3pleCiqlWjJN83pWl5Dwq4ZsNodDicDtO0A4lgub+YdSgdjqetF1GAmPaw/SX6eR8J3WCNE6V95A="
+  TWINE_USERNAME: "__token__"   # token for PYPI test account for David Keeney.  Not for production
+  TWINE_PASSWORD: "pypi-AgENdGVzdC5weXBpLm9yZwIkOTk0YmZjNGYtZTgxNS00Yjk2LTg5ZTAtODE1MGI4MjZhNGZlAAIleyJwZXJtaXNzaW9ucyI6ICJ1c2VyIiwgInZlcnNpb24iOiAxfQAABiDXJOuxvodsEDoD5dOH-e0td1DdUSwrl2NCl_lP_vy6RA"
 
-## PyPI support (pip install twine)
-#  PYPI_USERNAME: numenta
-#  PYPI_PASSWORD:
-#    secure: UgABryPYZg823OcD1XRosA==
 
   matrix:
 #    # Win64-gcc
@@ -91,8 +89,6 @@ matrix:
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
-before_build:
-#  - ps: gitversion /l console /output buildserver
 
 build_script:
   # Dump appveyor build vars for diagnostics
@@ -139,33 +135,34 @@ artifacts:
   - path: 'build\scripts\*.zip'
     name: htm.core
 
-# NOTE: This is turned off and will likely be removed once deployments of
-#       releases are controlled from a central authority. -- Matt
 # -----------------------------------------------------------------------
-# on_success:
-#   # Github tagged builds
-#   - cmd: echo "executing on_success"
-#   - ps: >-
-#       If ($env:APPVEYOR_REPO_TAG -eq "true" -or $env:APPVEYOR_REPO_TAG -eq "True") {
-#         Write-Host "Uploading bindings to PYPI"
-#         pip install httplib requests twine --upgrade
-#         twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD -r pypi $env:HTM_CORE\bindings\py\dist\htm.bindings-$env:BINDINGS_VERSION-cp27-none-$env:wheel_name_suffix.whl
-#       }
+# PYPI
+on_success:
+  # Github tagged builds
+  - cmd: echo "executing on_success"
+  - ps: >-
+      If ($env:APPVEYOR_REPO_TAG -eq "true" -or $env:APPVEYOR_REPO_TAG -eq "True") {
+        Write-Host "Uploading bindings to PYPI"
+        pip install httplib requests twine --upgrade
+        twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD -r testpypi build/Release/distr/dist/*.whl
+      }
 
-    #deploy:
-    ### GitHub
+deploy:
+    ## GitHub
     ## Deploy to GitHub Releases
     ## see https://www.appveyor.com/docs/deployment/github/
     ##
-    #  release: 'testing' #htmcore-win64-v$(appveyor_build_version)
-    #  description: 'HTM.core binary release for Windows (64bit)' #desc is mandatory
-    #  provider: GitHub
-    #  auth_token: 
-    #    secure: "%GITHUB_TOKEN%"
-    #  artifact: '\build\scripts\*.zip' # upload .zip from 'make package'
-    #  draft: false
-    #  prerelease: false
-    #  force_update: true #override files in existing release
-    #  on:
-    #    branch: master                # release from master branch only
-    #    appveyor_repo_tag: true       # deploy on tag push only
+   release: 'htm.core' #htmcore-win64-v$(appveyor_build_version)
+      description: 'HTM.core binary release '
+      provider: GitHub
+      auth_token: 
+        secure: "%GITHUB_TOKEN%"
+      artifact: 'build\scripts\*.zip' # upload .zip from 'make package'
+      draft: false
+      prerelease: false
+      force_update: true #override files in existing release
+      on:
+        branch: master                # release from master branch only
+        appveyor_repo_tag: true       # deploy on tag push only
+        
+    


### PR DESCRIPTION
The idea is that a release is initiated by creating a release on GitHub Releases.  The following actions happen.
- A GitHub Releases object is created with no artifacts.
- The master is tagged with the new version.
- The tagging causes all three CI's to build.  This requires special scripting for a tagged master.
- As each CI finishes its build it will create the release package
- Each CI will then upload the package to the GitHub Releases object.
- Each CI will then extract the wheel from the package and  upload the wheel to PYPI.