### PR TITLE
Trying to deploy only on tagged builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,8 @@ jobs:
       - run:
           name: "Publish Release on PYPI"
           command: |
-            python3 -m pip install twine
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user twine
             cd build/scripts
             mkdir artifact
             for file in ./*.tar.gz ; do
@@ -253,19 +254,22 @@ workflows:
           requires:
             - osx-build-release
           filters:
+            # ignore on any commit on any branch by default
             branches:
-              only: master
+              ignore: /.*/
+            # But act on tagged events
             tags:
-              only: /v.*/
+              only: /^v[0-9]+(\.[0-9]+)*$/
               
       - osx-deploy-pypi:
           requires:
             - osx-build-release
           filters:
+            # ignore on any commit on any branch by default
             branches:
-              only: master
-            tags:
-              only: /v.*/
+              ignore: /.*/
+            # But act on tagged events
+              only: /^v[0-9]+(\.[0-9]+)*$/
 
   nightly: # build and tests taking long time (currecntly ARM64 build ~5hrs), runs only once a day
     triggers:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,23 +138,24 @@ artifacts:
 # -----------------------------------------------------------------------
 # PYPI
 on_success:
-  # Github tagged builds
-  - cmd: echo "executing on_success"
-  - ps: >-
-      If ($env:APPVEYOR_REPO_TAG -eq "true" -or $env:APPVEYOR_REPO_TAG -eq "True") {
-        Write-Host "Uploading bindings to PYPI"
-        pip install httplib requests twine --upgrade
-        twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD -r testpypi build/Release/distr/dist/*.whl
-      }
+    # Only for tagged master builds
+    # PYPI is not a known 'provider' so it cannot go in the deploy: section
+    - cmd: echo "executing on_success"
+    - ps: >-
+        If ($env:APPVEYOR_REPO -eq "master" -or $env:APPVEYOR_REPO_TAG -eq "True") {
+          Write-Host "Uploading bindings to PYPI"
+          pip install httplib requests twine --upgrade
+          twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD -r testpypi build/Release/distr/dist/*.whl
+        }
 
 deploy:
-    ## GitHub
-    ## Deploy to GitHub Releases
-    ## see https://www.appveyor.com/docs/deployment/github/
-    ##
+  ## GitHub
+  ## Deploy to GitHub Releases
+  ## see https://www.appveyor.com/docs/deployment/github/
+  ##
+  - provider: GitHub
     release: 'htm.core' #htmcore-win64-v$(appveyor_build_version)
     description: 'HTM.core binary release '
-    provider: GitHub
     auth_token: 
         secure: "%GITHUB_TOKEN%"
     artifact: 'build\scripts\*.zip' # upload .zip from 'make package'
@@ -162,7 +163,6 @@ deploy:
     prerelease: false
     force_update: true #override files in existing release
     on:
-        branch: master                # release from master branch only
-        appveyor_repo_tag: true       # deploy on tag push only
+      APPVEYOR_REPO_TAG: true    # deploy on tag push only
         
     


### PR DESCRIPTION
Trying slightly different syntax for selecting when to perform the deploy.  The filter clauses are OR not AND.   And making sure that twine is installed for PYPI deploy.