### PR TITLE
Changed SPRegion "synPermConnected" parameter access from ReadOnly to

### DIFF
--- a/bindings/py/tests/regions/sp_region_test.py
+++ b/bindings/py/tests/regions/sp_region_test.py
@@ -46,7 +46,6 @@ class SPRegionTests(unittest.TestCase):
         # Create simple region to pass sensor commands as displacement vectors (dx, dy)
         sp = net.addRegion("sp", "SPRegion", json.dumps({}))
         
-    @unittest.skip("synPermConnected is rejected")
     def testSPRegionParametersAreWritable(self):
         """
         Test that the SPRegion parameters can be set.

--- a/src/htm/regions/SPRegion.cpp
+++ b/src/htm/regions/SPRegion.cpp
@@ -349,7 +349,7 @@ Spec *SPRegion::createSpec() {
                     1,                                // elementCount
                     "",                               // constraints
                     "0.1",                            // defaultValue
-                    ParameterSpec::ReadOnlyAccess)); // access
+                    ParameterSpec::CreateAccess)); // access
 
   ns->parameters.add(
       "minPctOverlapDutyCycles",


### PR DESCRIPTION
Wanted to make sure that this didn't fall between the cracks.
Also, I need this right now.
Please note that I enabled the test for this in the pyBind tests
Good to see that CreateAccess in the .cpp code works as advertised. :-)