### PR TITLE
Classifier: use map to allow sparse categories WIP

### DIFF
--- a/src/htm/algorithms/SDRClassifier.hpp
+++ b/src/htm/algorithms/SDRClassifier.hpp
@@ -146,25 +146,25 @@ public:
   {
     ar(cereal::make_nvp("alpha",         alpha_),
        cereal::make_nvp("dimensions",    dimensions_),
-       cereal::make_nvp("numCategories", numCategories_),
+       cereal::make_nvp("categories",    categories_),
        cereal::make_nvp("weights",       weights_));
   }
 
   template<class Archive>
   void load_ar(Archive & ar)
-    { ar( alpha_, dimensions_, numCategories_, weights_ ); }
+    { ar( alpha_, dimensions_, categories_, weights_ ); }
 
 private:
   Real alpha_;
   UInt dimensions_;
-  size_t numCategories_;
+  std::vector<UInt> categories_;
 
   /**
    * 2D map used to store the data.
    * Use as: weights_[ input-bit ][ category-index ]
    * Real64 (not just Real) so the computations do not lose precision.
    */
-  std::vector<std::vector<Real64>> weights_;
+  std::vector<std::unordered_map<UInt, Real64>> weights_;
 
   // Helper function to compute the error signal for learning.
   std::vector<Real64> calculateError_(const std::vector<UInt> &bucketIdxList,


### PR DESCRIPTION
use map internally for categories_, instead of vector, which allows us
to have sparse {1,2,999} categories (=3 total). Instead, with vector
this would have to be 999 categories!

Do not merge, for review comments only. Attempt to switch from using continuous label indices to non-cont. labels in Classifier. 