### PR TITLE
PYPI: publish build artifacts 

### DIFF
--- a/.github/workflows/htmcore.yml
+++ b/.github/workflows/htmcore.yml
@@ -91,12 +91,39 @@ jobs:
         name: "dist-${{ matrix.os }}"
         path: build/Release/distr/dist
 
+
+  publish-pypi:
+    name: Publish package to PYPI
+    needs:
+      build
+    runs-on: ubuntu-18.04
+    steps:
+
+    - uses: actions/checkout@master
+
+    - uses: actions/download-artifact@master
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      with:
+        name: dist-ubuntu-18.04
+        path: dist1/
+
+    - uses: actions/download-artifact@master
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      with:
+        name: dist-macOs-latest
+        path: dist2/
+
+    - uses: actions/download-artifact@master
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      with:
+        name: dist-windows-2019
+        path: dist3/
+
     - name: pre-PyPI
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && 1==0
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       #copy dist data to /dist, where PyPI Action expects it
       run: |
-        cp -a build/Release/distr/dist .
-        ls dist
+        ls dist*
 
     - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-18.04' && 1==0

--- a/.github/workflows/htmcore.yml
+++ b/.github/workflows/htmcore.yml
@@ -86,14 +86,15 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: pre-PyPI
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && 1==0
       #copy dist data to /dist, where PyPI Action expects it
       run: |
         cp -a build/Release/distr/dist .
         ls dist
 
     - name: Publish to PyPI
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-18.04'
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-18.04' && 1==0
+      #FIXME temp disabled as pypi-publisher action must run on Linux only!
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__

--- a/.github/workflows/htmcore.yml
+++ b/.github/workflows/htmcore.yml
@@ -85,6 +85,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: actions/upload-artifact@v1.0.0
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      with:
+        name: "dist-${{ matrix.os }}"
+        path: build/Release/distr/dist
+
     - name: pre-PyPI
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && 1==0
       #copy dist data to /dist, where PyPI Action expects it


### PR DESCRIPTION
and collect them for PYPI uploader action. 

For #19 
