### PR TITLE
Retina broken log polar WIP

### DIFF
--- a/py/htm/encoders/eye.py
+++ b/py/htm/encoders/eye.py
@@ -259,10 +259,10 @@ class Eye:
           assert(sparsityParvo > 0)
         self.color = color
 
-        reductionFactor_ = max(inputShape)/output_diameter
+        reductionFactor_ = inputShape[0]/output_diameter #TODO how would this work with non-square images?
         assert(reductionFactor_ >= 1.0)
         self.retina = cv2.bioinspired.Retina_create(
-            inputSize            = (max(inputShape), max(inputShape)), #FIXME avoid transformation to the bigger square, work with rectangles
+            inputSize            = inputShape,
             colorMode            = color,
             colorSamplingMethod  = cv2.bioinspired.RETINA_COLOR_BAYER,
             useRetinaLogSampling = True,
@@ -457,6 +457,7 @@ class Eye:
         self.roi = self._crop_roi()
 
         # Retina image transforms (Parvo & Magnocellular).
+        print("IMG", self.image.shape)
         self.retina.run(self.roi)
 
         # Encode images into SDRs.

--- a/py/htm/encoders/eye.py
+++ b/py/htm/encoders/eye.py
@@ -177,6 +177,11 @@ class Eye:
     Simulates functionality of eye's retinal parvocellular(P-cells),
     and magnocellular(M-cells) pathways, at the saccadic steps. 
 
+    Based on OpenCV's cv2.bioinspired.Retina model: 
+    https://docs.opencv.org/3.4/d2/d94/bioinspired_retina.html
+    http://web.iitd.ac.in/~sumeet/Modelling_Vision.pdf
+
+
     On high level, 
     magno cells: 
       - detect change in temporal information in the image, ie motion 
@@ -238,7 +243,7 @@ class Eye:
             motion detection and motion tracking, video processing.
             For details see @param `sparsityParvo`.
             TODO: output of M-cells should be processed on a fast TM.
-        Argument color: use color vision (requires P-cells > 0), default true.
+        Argument color: use color vision (requires P-cells > 0), default true. (Grayscale is faster)
         """
         self.output_diameter   = output_diameter
         # Argument resolution_factor is used to expand the sensor array so that
@@ -267,6 +272,10 @@ class Eye:
             inputSize            = (self.retina_diameter, self.retina_diameter),
             colorMode            = color,
             colorSamplingMethod  = cv2.bioinspired.RETINA_COLOR_BAYER,)
+
+        # Activate Parvo/Magno vision based on whether sparsityXXX is set.
+        self.retina.activateContoursProcessing(sparsityParvo > 0) # Parvo
+        self.retina.activateMovingContoursProcessing(sparsityMagno > 0) # Magno
 
         print(self.retina.printSetup())
         print()

--- a/py/htm/encoders/eye.py
+++ b/py/htm/encoders/eye.py
@@ -261,10 +261,10 @@ class Eye:
           assert(sparsityParvo > 0)
         self.color = color
 
-        reductionFactor_ = inputShape[0]/output_diameter #TODO how would this work with non-square images?
+        reductionFactor_ = max(inputShape)/output_diameter
         assert(reductionFactor_ >= 1.0)
         self.retina = cv2.bioinspired.Retina_create(
-            inputSize            = inputShape,
+            inputSize            = (max(inputShape), max(inputShape)), #FIXME avoid transformation to the bigger square, work with rectangles
             colorMode            = color,
             colorSamplingMethod  = cv2.bioinspired.RETINA_COLOR_BAYER,
             useRetinaLogSampling = True,
@@ -453,16 +453,14 @@ class Eye:
         self.roi = self._crop_roi()
 
         # Retina image transforms (Parvo & Magnocellular).
-        print("IMG", self.image.shape)
         self.retina.run(self.roi)
         if self.parvo_enc is not None:
           parvo = self.retina.getParvo()
-          print("RAW", parvo.shape)
         if self.magno_enc is not None:
           magno = self.retina.getMagno()
 
         # Apply rotation by rolling the images around axis 1.
-        rotation = self.retina.getOutputSize()[0] * self.orientation / (2 * math.pi) #TODO rotate before retina processes stuff
+        rotation = max(self.retina.getOutputSize()) * self.orientation / (2 * math.pi) #TODO rotate before retina processes stuff
         rotation = int(round(rotation))
         if self.parvo_enc is not None:
           self.parvo_img = np.roll(parvo, rotation, axis=0)


### PR DESCRIPTION
WIP PR, I made some cleanups,improvements to the PR, but broke scaling/logpolar. 

What I'd like to do is use Retina's `useLogSampling`, but imho that unfortunately
- does not do logpolar transformation (only log scaling?) 
- does not allow to set center&diameter of fovea

Our current approach is neither ideal, 
- we have to crop to ROI
- I'd like to re-center the image to given center (& fov. diameter) 
  - then apply log polar to all of the image
  - then apply log-scale reduction as is in Retina (so parts further from fovea become blurred, encoded with lesser precision) 


- What is the difference for `self.scale` and `self.scale_fovea` ? 
  - is scaling working properly, incl plots? 

Follow up to #691 