### PR TITLE
switch from building with distutils to setuptools in setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install gcc-8 g++-8
-        python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements.txt
         python setup.py configure
 
     - name: Install dependencies
       if: matrix.os != 'ubuntu-18.04'
       run: |
-        python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements.txt
         python setup.py configure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
 setuptools>=34.4.0 # needed for Windows with MSVC
+pip>=19.3.1
+wheel>=0.33.6
 ## for python bindings (in /bindings/py/)
 numpy>=1.15
 pytest==4.6.5 #4.6.x series is last to support python2, once py2 dropped, we can switch to 5.x 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
+setuptools>=34.4.0 # needed for Windows with MSVC
 ## for python bindings (in /bindings/py/)
 numpy>=1.15
 pytest==4.6.5 #4.6.x series is last to support python2, once py2 dropped, we can switch to 5.x 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ import json
 
 from setuptools import Command, find_packages, setup
 from setuptools.command.test import test as BaseTestCommand
-from distutils.core import Extension
+#from distutils.core import Extension
+# see https://stackoverflow.com/questions/44323474/distutils-core-vs-setuptools-with-c-extension
+from setuptools import Extension
 
 # NOTE:  To debug the python bindings in a debugger, use the procedure
 #        described here: https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_in_ide.html
@@ -376,8 +378,7 @@ if __name__ == "__main__":
   os.chdir(DISTR_DIR)
 
   setup(
-    # See https://docs.python.org/2/distutils/apiref.html for descriptions of arguments.
-    #     https://docs.python.org/2/distutils/setupscript.html
+    # See https://setuptools.readthedocs.io/en/latest/setuptools.html
     #     https://opensourceforu.com/2010/OS/extending-python-via-shared-libraries
     #     https://docs.python.org/3/library/ctypes.html
     #     https://docs.python.org/2/library/imp.html

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ import json
 
 from setuptools import Command, find_packages, setup
 from setuptools.command.test import test as BaseTestCommand
-#from distutils.core import Extension
+from distutils.core import Extension
 # see https://stackoverflow.com/questions/44323474/distutils-core-vs-setuptools-with-c-extension
-from setuptools import Extension
+#from setuptools import Extension
 
 # NOTE:  To debug the python bindings in a debugger, use the procedure
 #        described here: https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_in_ide.html

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ import json
 
 from setuptools import Command, find_packages, setup
 from setuptools.command.test import test as BaseTestCommand
-from distutils.core import Extension
 # see https://stackoverflow.com/questions/44323474/distutils-core-vs-setuptools-with-c-extension
-#from setuptools import Extension
+from setuptools import Extension
 
 # NOTE:  To debug the python bindings in a debugger, use the procedure
 #        described here: https://pythonextensionpatterns.readthedocs.io/en/latest/debugging/debug_in_ide.html


### PR DESCRIPTION
I wanted to see if everything builds in CI with this change.  But do not merge until we here from @be4pro who I requested to check if it works when only Visual Studio 2019 is installed.