### PR TITLE
Using Create rather than Read Access in python regions

### DIFF
--- a/bindings/py/cpp_src/CMakeLists.txt
+++ b/bindings/py/cpp_src/CMakeLists.txt
@@ -106,6 +106,7 @@ file(COPY ${REPOSITORY_DIR}/bindings/py/packaging/. DESTINATION ${distr} REGEX  
 #file(COPY ${REPOSITORY_DIR}/bindings/py/tests/. DESTINATION ${distr}/src/htm/tests REGEX  ".*__pycache__" EXCLUDE)
 file(COPY ${REPOSITORY_DIR}/py/htm/. DESTINATION ${distr}/src/htm REGEX  ".*__pycache__" EXCLUDE)
 #file(COPY ${REPOSITORY_DIR}/py/tests/. DESTINATION ${distr}/src/htm/tests REGEX  ".*__pycache__" EXCLUDE)
+message(STATUS "Copied .py sources to ${distr}/src/htm")
 
 # determine which version of binding to build
 if ("${BINDING_BUILD}" STREQUAL "Python2")

--- a/external/pybind11.cmake
+++ b/external/pybind11.cmake
@@ -20,7 +20,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/pybind11.tar.gz")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/pybind11.tar.gz")
 else()
-    set(URL https://github.com/pybind/pybind11/archive/v2.4.2.tar.gz)
+    set(URL https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz)
 endif()
 
 message(STATUS "obtaining PyBind11")

--- a/py/htm/advanced/regions/ApicalTMPairRegion.py
+++ b/py/htm/advanced/regions/ApicalTMPairRegion.py
@@ -152,7 +152,7 @@ class ApicalTMPairRegion(PyRegion):
                 "columnCount": {
                     "description": ("The size of the 'activeColumns' input "
                                     "(i.e. the number of columns)"),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -161,7 +161,7 @@ class ApicalTMPairRegion(PyRegion):
 
                 "basalInputWidth": {
                     "description": "The size of the 'basalInput' input",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -170,7 +170,7 @@ class ApicalTMPairRegion(PyRegion):
 
                 "apicalInputWidth": {
                     "description": "The size of the 'apicalInput' input",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -186,7 +186,7 @@ class ApicalTMPairRegion(PyRegion):
                 },
                 "cellsPerColumn": {
                     "description": "Number of cells per column",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -196,7 +196,6 @@ class ApicalTMPairRegion(PyRegion):
                     "description": ("If the number of active connected synapses on a "
                                     "segment is at least this threshold, the segment "
                                     "is said to be active."),
-                    "accessMode": "Read",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -206,7 +205,7 @@ class ApicalTMPairRegion(PyRegion):
                     "description": ("Activation threshold of basal segments for cells "
                                     "with active apical segments (with apicalTiebreak "
                                     "implementation). "),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -214,7 +213,7 @@ class ApicalTMPairRegion(PyRegion):
                 },
                 "initialPermanence": {
                     "description": "Initial permanence of a new synapse.",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1,
                     "constraints": "",
@@ -233,7 +232,7 @@ class ApicalTMPairRegion(PyRegion):
                     "description": ("If the number of synapses active on a segment is at "
                                     "least this threshold, it is selected as the best "
                                     "matching cell in a bursting column."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": "",
@@ -242,7 +241,7 @@ class ApicalTMPairRegion(PyRegion):
                 "sampleSize": {
                     "description": ("The desired number of active synapses for an "
                                     "active cell"),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "accessMode":"ReadWrite"
@@ -250,7 +249,7 @@ class ApicalTMPairRegion(PyRegion):
                 "learnOnOneCell": {
                     "description": ("If True, the winner cell for each column will be"
                                     " fixed between resets."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Bool",
                     "count": 1,
                     "defaultValue": "false",
@@ -274,7 +273,7 @@ class ApicalTMPairRegion(PyRegion):
                 "permanenceIncrement": {
                     "description": ("Amount by which permanences of synapses are "
                                                     "incremented during learning."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1,
                     "accessMode":"ReadWrite"
@@ -282,7 +281,7 @@ class ApicalTMPairRegion(PyRegion):
                 "permanenceDecrement": {
                     "description": ("Amount by which permanences of synapses are "
                                     "decremented during learning."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1,
                     "accessMode":"ReadWrite"
@@ -307,14 +306,14 @@ class ApicalTMPairRegion(PyRegion):
                 },
                 "seed": {
                     "description": "Seed for the random number generator.",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "accessMode":"ReadWrite"
                 },
                 "implementation": {
                     "description": "Apical implementation",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Byte",
                     "count": 0,
                     "constraints": ("enum: ApicalTiebreak, ApicalTiebreakCPP, ApicalDependent"),

--- a/py/htm/advanced/regions/ApicalTMSequenceRegion.py
+++ b/py/htm/advanced/regions/ApicalTMSequenceRegion.py
@@ -132,14 +132,14 @@ class ApicalTMSequenceRegion(PyRegion):
                 "columnCount": {
                     "description": ("The size of the 'activeColumns' input " +
                                     "(i.e. the number of columns)"),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": ""
                 },
                 "apicalInputWidth": {
                     "description": "The size of the 'apicalInput' input",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": ""
@@ -154,7 +154,7 @@ class ApicalTMSequenceRegion(PyRegion):
                 },
                 "cellsPerColumn": {
                     "description": "Number of cells per column",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": ""
@@ -163,7 +163,7 @@ class ApicalTMSequenceRegion(PyRegion):
                     "description": ("If the number of active connected synapses on a "
                                     "segment is at least this threshold, the segment "
                                     "is said to be active."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": ""
@@ -172,14 +172,14 @@ class ApicalTMSequenceRegion(PyRegion):
                     "description": ("Activation threshold of basal segments for cells "
                                     "with active apical segments (with apicalTiebreak "
                                     "implementation). "),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": ""
                 },
                 "initialPermanence": {
                     "description": "Initial permanence of a new synapse.",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1,
                     "constraints": ""
@@ -187,7 +187,7 @@ class ApicalTMSequenceRegion(PyRegion):
                 "connectedPermanence": {
                     "description": ("If the permanence value for a synapse is greater "
                                     "than this value, it is said to be connected."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1,
                     "constraints": ""
@@ -196,7 +196,7 @@ class ApicalTMSequenceRegion(PyRegion):
                     "description": ("If the number of synapses active on a segment is at "
                                     "least this threshold, it is selected as the best "
                                     "matching cell in a bursting column."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1,
                     "constraints": ""
@@ -204,41 +204,41 @@ class ApicalTMSequenceRegion(PyRegion):
                 "sampleSize": {
                     "description": ("The desired number of active synapses for an " +
                                     "active cell"),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1
                 },
                 "learnOnOneCell": {
                     "description": ("If True, the winner cell for each column will be"
                                     " fixed between resets."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Bool",
                     "count": 1,
                     "defaultValue": "false"
                 },
                 "maxSynapsesPerSegment": {
                     "description": "The maximum number of synapses per segment",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1
                 },
                 "maxSegmentsPerCell": {
                     "description": "The maximum number of segments per cell",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1
                 },
                 "permanenceIncrement": {
                     "description": ("Amount by which permanences of synapses are "
                                     "incremented during learning."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1
                 },
                 "permanenceDecrement": {
                     "description": ("Amount by which permanences of synapses are "
                                     "decremented during learning."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1
                 },
@@ -246,7 +246,7 @@ class ApicalTMSequenceRegion(PyRegion):
                     "description": ("Amount by which active permanences of synapses of "
                                     "previously predicted but inactive segments are "
                                     "decremented."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1
                 },
@@ -254,19 +254,19 @@ class ApicalTMSequenceRegion(PyRegion):
                     "description": ("Amount by which active permanences of synapses of "
                                     "previously predicted but inactive segments are "
                                     "decremented."),
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Real32",
                     "count": 1
                 },
                 "seed": {
                     "description": "Seed for the random number generator.",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "UInt32",
                     "count": 1
                 },
                 "implementation": {
                     "description": "Apical implementation",
-                    "accessMode": "Read",
+                    "accessMode": "Create",
                     "dataType": "Byte",
                     "count": 0,
                     "constraints": ("enum: ApicalTiebreak, ApicalTiebreakCPP, ApicalDependent"),

--- a/py/htm/advanced/regions/ColumnPoolerRegion.py
+++ b/py/htm/advanced/regions/ColumnPoolerRegion.py
@@ -149,19 +149,21 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    defaultValue="false"),
+                    defaultValue="0"),
                 cellCount=dict(
                     description="Number of cells in this layer",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="4096"),
                 inputWidth=dict(
                     description='Number of inputs to the layer.',
                     accessMode='ReadWrite',
                     dataType='UInt32',
                     count=1,
-                    constraints=''),
+                    constraints='',
+                    defaultValue="16384"),
                 numOtherCorticalColumns=dict(
                     description="The number of lateral inputs that this L2 will receive. "
                                 "This region assumes that every lateral input is of size "
@@ -169,20 +171,23 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="0"),
                 sdrSize=dict(
                     description="The number of active cells invoked per object",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="40"),
                 maxSdrSize=dict(
                     description="The largest number of active cells in an SDR tolerated "
                                 "during learning. Stops learning when unions are active.",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue=""),
                 minSdrSize=dict(
                     description="The smallest number of active cells in an SDR tolerated "
                                 "during learning.    Stops learning when possibly on a "
@@ -190,7 +195,8 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue=""),
 
                 #
                 # Proximal
@@ -200,24 +206,28 @@ class ColumnPoolerRegion(PyRegion):
                                 "incremented during learning.",
                     accessMode="ReadWrite",
                     dataType="Real32",
-                    count=1),
+                    count=1,
+                    defaultValue="0.1"),
                 synPermProximalDec=dict(
                     description="Amount by which permanences of proximal synapses are "
                                 "decremented during learning.",
                     accessMode="ReadWrite",
                     dataType="Real32",
-                    count=1),
+                    count=1,
+                    defaultValue="0.001"),
                 initialProximalPermanence=dict(
                     description="Initial permanence of a new proximal synapse.",
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="0.6"),
                 sampleSizeProximal=dict(
                     description="The desired number of active synapses for an active cell",
                     accessMode="ReadWrite",
                     dataType="Int32",
-                    count=1),
+                    count=1,
+                    defaultValue="20"),
                 minThresholdProximal=dict(
                     description="If the number of synapses active on a proximal segment "
                                 "is at least this threshold, it is considered as a "
@@ -225,14 +235,16 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="1"),
                 connectedPermanenceProximal=dict(
                     description="If the permanence value for a synapse is greater "
                                 "than this value, it is said to be connected.",
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="0.50"),
                 predictedInhibitionThreshold=dict(
                     description="How many predicted cells are required to cause "
                                 "inhibition in the pooler.    Only has an effect if online "
@@ -240,7 +252,8 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="20"),
 
                 #
                 # Distal
@@ -250,25 +263,29 @@ class ColumnPoolerRegion(PyRegion):
                                 "incremented during learning.",
                     accessMode="ReadWrite",
                     dataType="Real32",
-                    count=1),
+                    count=1,
+                    defaultValue="0.10"),
                 synPermDistalDec=dict(
                     description="Amount by which permanences of synapses are "
                                 "decremented during learning.",
                     accessMode="ReadWrite",
                     dataType="Real32",
-                    count=1),
+                    count=1,
+                    defaultValue="0.10"),
                 initialDistalPermanence=dict(
                     description="Initial permanence of a new synapse.",
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="0.21"),
                 sampleSizeDistal=dict(
                     description="The desired number of active synapses for an active "
                                 "segment.",
                     accessMode="ReadWrite",
                     dataType="Int32",
-                    count=1),
+                    count=1,
+                    defaultValue="20"),
                 activationThresholdDistal=dict(
                     description="If the number of synapses active on a distal segment is "
                                 "at least this threshold, the segment is considered "
@@ -276,14 +293,16 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="13"),
                 connectedPermanenceDistal=dict(
                     description="If the permanence value for a synapse is greater "
                                 "than this value, it is said to be connected.",
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="0.50"),
                 inertiaFactor=dict(
                     description="Controls the proportion of previously active cells that "
                                 "remain active through inertia in the next timestep (in    "
@@ -291,7 +310,8 @@ class ColumnPoolerRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    constraints=""),
+                    constraints="",
+                    defaultValue="1.0"),
 
 
 
@@ -299,7 +319,8 @@ class ColumnPoolerRegion(PyRegion):
                     description="Seed for the random number generator.",
                     accessMode="ReadWrite",
                     dataType="UInt32",
-                    count=1),
+                    count=1,
+                    defaultValue="42"),
                 defaultOutputType=dict(
                     description="Controls what type of cell output is placed into"
                                 " the default output 'feedForwardOutput'",

--- a/py/htm/advanced/regions/GridCellLocationRegion.py
+++ b/py/htm/advanced/regions/GridCellLocationRegion.py
@@ -181,7 +181,7 @@ class GridCellLocationRegion(PyRegion):
                     dataType="Real32",
                     accessMode="ReadWrite",
                     count=1,
-                    defaultValue=0.18172,
+                    defaultValue="0.18172",
                 ),
                 activationThreshold=dict(
                     description="If the number of active connected synapses on a "
@@ -191,7 +191,7 @@ class GridCellLocationRegion(PyRegion):
                     dataType="UInt32",
                     count=1,
                     constraints="",
-                    defaultValue=10
+                    defaultValue="10"
                 ),
                 initialPermanence=dict(
                     description="Initial permanence of a new synapse",
@@ -199,7 +199,7 @@ class GridCellLocationRegion(PyRegion):
                     dataType="Real32",
                     count=1,
                     constraints="",
-                    defaultValue=0.21
+                    defaultValue="0.21"
                 ),
                 connectedPermanence=dict(
                     description="If the permanence value for a synapse is greater "
@@ -208,14 +208,14 @@ class GridCellLocationRegion(PyRegion):
                     dataType="Real32",
                     count=1,
                     constraints="",
-                    defaultValue=0.50
+                    defaultValue="0.50"
                 ),
                 learningThreshold=dict(
                     description="Minimum overlap required for a segment to learned",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    defaultValue=10
+                    defaultValue="10"
                 ),
                 sampleSize=dict(
                     description="The desired number of active synapses for an "
@@ -223,7 +223,7 @@ class GridCellLocationRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    defaultValue=20
+                    defaultValue="20"
                 ),
                 permanenceIncrement=dict(
                     description="Amount by which permanences of synapses are "
@@ -231,7 +231,7 @@ class GridCellLocationRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    defaultValue=0.1
+                    defaultValue="0.1"
                 ),
                 permanenceDecrement=dict(
                     description="Amount by which permanences of synapses are "
@@ -239,14 +239,14 @@ class GridCellLocationRegion(PyRegion):
                     accessMode="ReadWrite",
                     dataType="Real32",
                     count=1,
-                    defaultValue=0.0
+                    defaultValue="0.0"
                 ),
                 maxSynapsesPerSegment=dict(
                     description="The maximum number of synapses per segment",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    defaultValue=-1
+                    defaultValue="-1"
                 ),
                 bumpOverlapMethod=dict(
                     description="Specifies the firing rate of a cell when it's part of "
@@ -264,7 +264,7 @@ class GridCellLocationRegion(PyRegion):
                     dataType="Bool",
                     accessMode="ReadWrite",
                     count=1,
-                    defaultValue=False
+                    defaultValue="False"
                 ),
                 dualPhase=dict(
                     description="A boolean flag that indicates whether or not we should "
@@ -276,21 +276,21 @@ class GridCellLocationRegion(PyRegion):
                     dataType="Bool",
                     accessMode="ReadWrite",
                     count=1,
-                    defaultValue=True
+                    defaultValue="True"
                 ),
                 dimensions=dict(
                     description="The number of dimensions represented in the displacement",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    defaultValue=2
+                    defaultValue="2"
                 ),
                 seed=dict(
                     description="Seed for the random number generator",
                     accessMode="ReadWrite",
                     dataType="UInt32",
                     count=1,
-                    defaultValue=42
+                    defaultValue="42"
                 )
             ),
             commands=dict(

--- a/py/htm/advanced/regions/RawSensor.py
+++ b/py/htm/advanced/regions/RawSensor.py
@@ -85,7 +85,7 @@ class RawSensor(PyRegion):
                     "dataType":"UInt32",
                     "accessMode":"ReadWrite",
                     "count":1,
-                    "defaultValue": 2048,
+                    "defaultValue": "2048",
                     "constraints":"",
                 },
                 "inputQueueData":{

--- a/py/htm/advanced/regions/RawValues.py
+++ b/py/htm/advanced/regions/RawValues.py
@@ -67,7 +67,7 @@ class RawValues(PyRegion):
                     dataType="UInt32",
                     accessMode="ReadWrite",
                     count=1,
-                    defaultValue=1,
+                    defaultValue="1",
                 )
             ),
             commands=dict(

--- a/src/htm/engine/Spec.cpp
+++ b/src/htm/engine/Spec.cpp
@@ -163,8 +163,10 @@ std::ostream& operator<< (std::ostream& out, const ParameterSpec& self) {
     case ParameterSpec::ReadWriteAccess: out << "ReadWriteAccess\n"; break;
     default: out << "UnknownAccess\n"; break;
     }
+    if (!self.defaultValue.empty())
+       out << "     defaultValue: " << self.defaultValue << "\n";
     if (!self.constraints.empty())
-       out << "     constraints" << self.constraints << "\n";
+       out << "     constraints: " << self.constraints << "\n";
     return out;
 }
 

--- a/src/htm/ntypes/BasicType.cpp
+++ b/src/htm/ntypes/BasicType.cpp
@@ -179,10 +179,12 @@ NTA_BasicType BasicType::parse(const std::string &s) {
     return NTA_BasicType_Real;
   else if (s == std::string("Handle"))
     return NTA_BasicType_Handle;
-  else if (s == std::string("Bool"))
+  else if (s == std::string("Bool") || s == std::string("bool"))
     return NTA_BasicType_Bool;
   else if (s == std::string("SDR"))
     return NTA_BasicType_SDR;
+  else if (s == std::string("Last"))
+    return NTA_BasicType_Last;  // Means none-of-the-above.
   else
     throw Exception(__FILE__, __LINE__,
                     std::string("Invalid basic type name: ") + s);


### PR DESCRIPTION
This started out to be a simple task of editing the python regions and changing the Access mode from Read to Create for parameters used in creation.

However, the code in PyBindRegion did not correctly parse the Spec from the python Regions so that needed to be debugged.  Added better error messages.

Then I found that the PyBindRegion code that prepared the parameters for the creation call of python Regions had some problems.  So that had to be fixed as well.

It all seems to checkout now.