### PR TITLE
all dependencies are tied to specific tag/commit version

### DIFF
--- a/external/README.md
+++ b/external/README.md
@@ -12,7 +12,7 @@ integrated into the cmake-based build of htm.core.  The code that does this are 
 - mnist_data.cmake - Downloads the mnist data set from repository master.
 - pybind11.cmake   - Downloads and installs pybind11 2.2.4  (header only)
 - YamlCppLib.cmake - Downloads and installs yaml-cpp master (something wrong with release 0.6.2)
-
+- libayml.cmake    - Downloads and installs libyaml which is an alternative to yaml-cpp (currently default) 
 
 External packages included within this repository are built into the common library:
 

--- a/external/libYaml.cmake
+++ b/external/libYaml.cmake
@@ -37,7 +37,7 @@ if(EXISTS   ${REPOSITORY_DIR}/build/ThirdParty/share/libyaml.zip)
 elif(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/libyaml.tar.gz)
     set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/libyaml.tar.gz)
 else()
-    set(URL "https://github.com/yaml/libyaml/archive/master.zip")
+    set(URL "https://github.com/yaml/libyaml/archive/53f5b8682317d8dbe9082d1eeab3cc0e1adbb34b.zip")
     #set(URL "http://pyyaml.org/download/libyaml/yaml-0.2.2.tar.gz")
 endif()
 

--- a/external/mnist_data.cmake
+++ b/external/mnist_data.cmake
@@ -20,8 +20,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/mnist.zip")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/mnist.zip")
 else()
-    set(URL "https://github.com/wichtounet/mnist/archive/master.zip")
-    #set(HASH "855cb8c60f84e2fc6bea08c4a9df9a3cbd6230bddc55def635a938665c512ffc")
+    set(URL "https://github.com/wichtounet/mnist/archive/3b65c35ede53b687376c4302eeb44fdf76e0129b.zip")
 endif()
 
 message(STATUS "obtaining MNIST data")


### PR DESCRIPTION
avoiding unfixed "master" downloads

Fixes #590 