### PR TITLE
Made references to Input and Output objects shared ptrs.

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -110,6 +110,8 @@ This is obsolete. Use getRegion('name') instead.
 
 * SpatialPooler: `compute()` now returns overlaps. `SP.getOverlaps()` removed. PR #552
 
+* Region:  `GetInput()` and `GetOutput()` now return std::shared_ptr's rather than raw pointers.
+
 
 ## Python API Changes
 

--- a/bindings/py/cpp_src/plugin/PyBindRegion.cpp
+++ b/bindings/py/cpp_src/plugin/PyBindRegion.cpp
@@ -618,7 +618,7 @@ namespace py = pybind11;
             const std::pair<std::string, OutputSpec> & p = ns.outputs.getByIndex(i);
 
             // Get the corresponding output buffer
-            Output * out = region_->getOutput(p.first);
+            auto out = region_->getOutput(p.first);
             // Skip optional outputs
             if (!out)
                 continue;

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -21,7 +21,8 @@ import pickle
 import numpy as np
 import unittest
 import pytest
-import time
+import timeit
+
 
 from htm.bindings.sdr import SDR
 from htm.bindings.math import Random
@@ -137,19 +138,15 @@ class SdrTest(unittest.TestCase):
 
         # Also, it should not be *too* much faster because this test-case is
         # tuned to very fast in both situations.
-        A = SDR( 100*1000 )
-        B = np.copy(A.dense)
-
-        copy_time = time.clock()
-        for i in range(100):
-            A.dense = B
-        copy_time = time.clock() - copy_time
-
-        inplace_time = time.clock()
-        for i in range(100):
-            A.dense = A.dense
-        inplace_time = time.clock() - inplace_time
-
+       
+       
+        
+        copy_time = timeit.timeit(stmt='A.dense = B', 
+                                  setup='import numpy as np;from htm.bindings.sdr import SDR;A = SDR( 100*1000 ); B = np.copy(A.dense)', 
+                                  number=100)
+        inplace_time = timeit.timeit(stmt='A.dense = A.dense', 
+                                  setup='from htm.bindings.sdr import SDR;A = SDR( 100*1000 )',
+                                  number=100)
         assert( inplace_time < copy_time / 3 )
 
     def testSparse(self):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,8 +98,6 @@ set(engine_files
     htm/engine/Link.hpp
     htm/engine/Network.cpp
     htm/engine/Network.hpp
-    htm/engine/NuPIC.cpp
-    htm/engine/NuPIC.hpp
     htm/engine/Output.cpp
     htm/engine/Output.hpp
     htm/engine/Region.cpp

--- a/src/htm/engine/Input.cpp
+++ b/src/htm/engine/Input.cpp
@@ -54,8 +54,8 @@ void Input::addLink(const std::shared_ptr<Link> link, std::shared_ptr<Output> sr
 
   // Make sure we don't already have a link to the same output
   for (const auto &it : links_) {
-    std::shared_ptr<Output> o = (*it).getSrc();
-    NTA_CHECK(srcOutput != o) << "addLink -- link from region "
+    const Output* o = (*it).getSrc();
+    NTA_CHECK(srcOutput.get() != o) << "addLink -- link from region "
                 << srcOutput->getRegion()->getName() << " output "
                 << srcOutput->getName() << " to region " << region_->getName()
                 << " input " << getName() << " already exists";
@@ -91,7 +91,7 @@ std::shared_ptr<Link> Input::findLink(const std::string &srcRegionName,
                                       const std::string &srcOutputName) {
   // Note: cannot use a map here because the link items are ordered.
   for (const auto &it: links_) {
-    const std::shared_ptr<Output> output = it->getSrc();
+    const Output* output = it->getSrc();
     if (output->getName() == srcOutputName &&
         output->getRegion()->getName() == srcRegionName) {
       return it;
@@ -187,7 +187,7 @@ void Input::initialize() {
     // Try to determine source dimensions.
     std::vector<Dimensions> Ds;
     for (auto link : links_) {
-      std::shared_ptr<Output> out = link->getSrc();
+      Output* out = link->getSrc();
       // determines source dimensions based on configuration.
       d = out->determineDimensions();
       NTA_CHECK(!d.isUnspecified());

--- a/src/htm/engine/Input.cpp
+++ b/src/htm/engine/Input.cpp
@@ -42,19 +42,20 @@ Input::~Input() {
   uninitialize();
   for (auto &link : links_) {
     std::cout << "Input::~Input: \n";
-    link->getSrc().removeLink(link); // remove it from the Output object.
+    link->getSrc()->removeLink(link); // remove it from the Output object.
     // the link is a shared_ptr so it will be deleted when links_ is cleared.
   }
   links_.clear();
 }
 
-void Input::addLink(const std::shared_ptr<Link> link, Output *srcOutput) {
+void Input::addLink(const std::shared_ptr<Link> link, std::shared_ptr<Output> srcOutput) {
   NTA_CHECK(initialized_ == false) << "Attempt to add link to input " << name_ << " on region "
               << region_->getName() << " when input is already initialized";
 
   // Make sure we don't already have a link to the same output
   for (const auto &it : links_) {
-    NTA_CHECK(srcOutput != &(*it).getSrc()) << "addLink -- link from region "
+    std::shared_ptr<Output> o = (*it).getSrc();
+    NTA_CHECK(srcOutput != o) << "addLink -- link from region "
                 << srcOutput->getRegion()->getName() << " output "
                 << srcOutput->getName() << " to region " << region_->getName()
                 << " input " << getName() << " already exists";
@@ -81,7 +82,7 @@ void Input::removeLink(const std::shared_ptr<Link> &link) {
   // We may have been initialized even if our containing region
   // was not. If so, uninitialize.
   uninitialize();
-  link->getSrc().removeLink(link);
+  link->getSrc()->removeLink(link);
   links_.erase(linkiter);
   // Link is deleted when the std::shared_ptr<Link> goes out of scope.
 }
@@ -90,9 +91,9 @@ std::shared_ptr<Link> Input::findLink(const std::string &srcRegionName,
                                       const std::string &srcOutputName) {
   // Note: cannot use a map here because the link items are ordered.
   for (const auto &it: links_) {
-    const Output &output = it->getSrc();
-    if (output.getName() == srcOutputName &&
-        output.getRegion()->getName() == srcRegionName) {
+    const std::shared_ptr<Output> output = it->getSrc();
+    if (output->getName() == srcOutputName &&
+        output->getRegion()->getName() == srcRegionName) {
       return it;
     }
   }
@@ -186,19 +187,19 @@ void Input::initialize() {
     // Try to determine source dimensions.
     std::vector<Dimensions> Ds;
     for (auto link : links_) {
-      Output &out = link->getSrc();
+      std::shared_ptr<Output> out = link->getSrc();
       // determines source dimensions based on configuration.
-      d = out.determineDimensions();
+      d = out->determineDimensions();
       NTA_CHECK(!d.isUnspecified());
       if (d.isDontcare()) {
         d = inD; // use destination dimensions for source. rare.
-        out.setDimensions(d);
+        out->setDimensions(d);
       }
       NTA_CHECK(d.isSpecified())
-          << "Cannot determine the dimensions for Output " << out.getRegion()->getName()
-          << "." << out.getName();
+          << "Cannot determine the dimensions for Output " << out->getRegion()->getName()
+          << "." << out->getName();
 
-      out.initialize(); // creates the output buffers.
+      out->initialize(); // creates the output buffers.
 
       // Initialize Link.  'total_width' at this point is the byte offset
       // into the input buffer where the output will start writing.
@@ -220,7 +221,7 @@ void Input::initialize() {
               << "Dimensions were specified for input "
               << region_->getName() << "." << name_ << " " << inD
               << " but it is inconsistant with the dimensions of the source "
-              << out.getRegion()->getName() << "." << out.getName() << " " << d;
+              << out->getRegion()->getName() << "." << out->getName() << " " << d;
           // else keep the manually configured dimensions.
         } else {
           inD = d;  // set the destination dimensions to be same as source.

--- a/src/htm/engine/Input.hpp
+++ b/src/htm/engine/Input.hpp
@@ -92,7 +92,7 @@ public:
    * @param srcOutput
    *        The output of previous Region, which is also the source of the input
    */
-  void addLink(const std::shared_ptr<Link> link, Output *srcOutput);
+  void addLink(const std::shared_ptr<Link> link, std::shared_ptr<Output> srcOutput);
 
   /**
    * Locate an existing Link to the input.

--- a/src/htm/engine/Link.cpp
+++ b/src/htm/engine/Link.cpp
@@ -42,7 +42,7 @@ Link::Link(const std::string &linkType, const std::string &linkParams,
 }
 
 Link::Link(const std::string &linkType, const std::string &linkParams,
-           Output *srcOutput, Input *destInput, const size_t propagationDelay) {
+           std::shared_ptr<Output> srcOutput, std::shared_ptr<Input> destInput, const size_t propagationDelay) {
   commonConstructorInit_(linkType, linkParams, srcOutput->getRegion()->getName(),
                          destInput->getRegion()->getName(), srcOutput->getName(),
                          destInput->getName(), propagationDelay);
@@ -54,8 +54,6 @@ Link::Link(const std::string &linkType, const std::string &linkParams,
 
 Link::Link() {  // needed for deserialization
   destOffset_ = 0;
-  src_ = nullptr;
-  dest_ = nullptr;
   initialized_ = false;
 }
 
@@ -75,8 +73,6 @@ void Link::commonConstructorInit_(const std::string &linkType,
   propagationDelay_ = propagationDelay;
   destOffset_ = 0;
   is_FanIn_ = false;
-  src_ = nullptr;
-  dest_ = nullptr;
   initialized_ = false;
 
 }
@@ -92,9 +88,9 @@ void Link::initialize(size_t destinationOffset, bool is_FanIn) {
   // and initialized.
 
   // Make sure we have been attached to a real network
-  NTA_CHECK(src_ != nullptr)
+  NTA_CHECK(src_)
       << "Link::initialize() and src_ Output object not set.";
-  NTA_CHECK(dest_ != nullptr)
+  NTA_CHECK(dest_)
       << "Link::initialize() and dest_ Input object not set.";
  
   destOffset_ = destinationOffset;
@@ -154,7 +150,7 @@ const std::string Link::toString() const {
   return ss.str();
 }
 
-void Link::connectToNetwork(Output *src, Input *dest) {
+void Link::connectToNetwork(std::shared_ptr<Output> src, std::shared_ptr<Input> dest) {
   NTA_CHECK(src != nullptr);
   NTA_CHECK(dest != nullptr);
 
@@ -163,18 +159,18 @@ void Link::connectToNetwork(Output *src, Input *dest) {
 }
 
 // The methods below only work on connected links.
-Output &Link::getSrc() const
+std::shared_ptr<Output> Link::getSrc() const
 
 {
-  NTA_CHECK(src_ != nullptr)
+  NTA_CHECK(src_)
       << "Link::getSrc() can only be called on a connected link";
-  return *src_;
+  return src_;
 }
 
-Input &Link::getDest() const {
-  NTA_CHECK(dest_ != nullptr)
+std::shared_ptr<Input> Link::getDest() const {
+  NTA_CHECK(dest_)
       << "Link::getDest() can only be called on a connected link";
-  return *dest_;
+  return dest_;
 }
 
 

--- a/src/htm/engine/Link.cpp
+++ b/src/htm/engine/Link.cpp
@@ -154,12 +154,12 @@ void Link::connectToNetwork(std::shared_ptr<Output> src, std::shared_ptr<Input> 
   NTA_CHECK(src != nullptr);
   NTA_CHECK(dest != nullptr);
 
-  src_ = src;
-  dest_ = dest;
+  src_ = src.get();
+  dest_ = dest.get();
 }
 
 // The methods below only work on connected links.
-std::shared_ptr<Output> Link::getSrc() const
+Output* Link::getSrc() const
 
 {
   NTA_CHECK(src_)
@@ -167,7 +167,7 @@ std::shared_ptr<Output> Link::getSrc() const
   return src_;
 }
 
-std::shared_ptr<Input> Link::getDest() const {
+Input* Link::getDest() const {
   NTA_CHECK(dest_)
       << "Link::getDest() can only be called on a connected link";
   return dest_;

--- a/src/htm/engine/Link.hpp
+++ b/src/htm/engine/Link.hpp
@@ -408,7 +408,7 @@ public:
    * @returns
    *         The source Output of the link
    */
-  std::shared_ptr<Output> getSrc() const;
+  Output* getSrc() const;
 
   /**
    *
@@ -417,7 +417,7 @@ public:
    * @returns
    *         The destination Input of the link
    */
-  std::shared_ptr<Input> getDest() const;
+  Input* getDest() const;
 
   /**
    * Copy data from source to destination.
@@ -514,9 +514,9 @@ private:
   std::string linkType_;
   std::string linkParams_;
 
-
-  std::shared_ptr<Output> src_;
-  std::shared_ptr<Input> dest_;
+  // Note: these must be raw pointers to avoid circular linkages with shared_ptrs.
+  Output* src_;
+  Input* dest_;
 
   // Each link contributes a contiguous chunk of the destination
   // input. The link needs to know its offset within the destination

--- a/src/htm/engine/Link.hpp
+++ b/src/htm/engine/Link.hpp
@@ -285,7 +285,7 @@ public:
    * @param dest
    *            The destination Input of the link
    */
-  void connectToNetwork(Output *src, Input *dest);
+  void connectToNetwork(std::shared_ptr<Output> src, std::shared_ptr<Input> dest);
 
   /*
    * Initialization Phase 1 and 2.
@@ -304,7 +304,7 @@ public:
    *            any, are initially populated with 0's. Defaults to 0=no delay
    */
   Link(const std::string &linkType, const std::string &linkParams,
-       Output *srcOutput, Input *destInput, size_t propagationDelay = 0);
+       std::shared_ptr<Output> srcOutput, std::shared_ptr<Input> destInput, size_t propagationDelay = 0);
 
 
   /**
@@ -408,7 +408,7 @@ public:
    * @returns
    *         The source Output of the link
    */
-  Output &getSrc() const;
+  std::shared_ptr<Output> getSrc() const;
 
   /**
    *
@@ -417,7 +417,7 @@ public:
    * @returns
    *         The destination Input of the link
    */
-  Input &getDest() const;
+  std::shared_ptr<Input> getDest() const;
 
   /**
    * Copy data from source to destination.
@@ -515,8 +515,8 @@ private:
   std::string linkParams_;
 
 
-  Output *src_;
-  Input *dest_;
+  std::shared_ptr<Output> src_;
+  std::shared_ptr<Input> dest_;
 
   // Each link contributes a contiguous chunk of the destination
   // input. The link needs to know its offset within the destination

--- a/src/htm/engine/Network.cpp
+++ b/src/htm/engine/Network.cpp
@@ -58,8 +58,28 @@ void Network::commonInit() {
 }
 
 Network::~Network() {
-  // The regions are deleted when the map goes out of scope.
+  /**
+   * Teardown choreography:
+   * - unintialize all regions because otherwise we won't be able to disconnect
+   * - remove all links, because we can't delete connected regions
+   *   This also removes Input and Output objects.
+   * - delete the regions themselves.
+   */
 
+  // 1. uninitialize
+  for(auto p: regions_) {
+    std::shared_ptr<Region> r = p.second;
+    r->uninitialize();
+  }
+
+  // 2. remove all links
+  for(auto p: regions_) {
+    std::shared_ptr<Region> r = p.second;
+    r->removeAllIncomingLinks();
+  }
+
+  // 3. delete the regions
+  // They are in a map of Shared_ptr so regions are deleted when it goes out of scope.
 }
 
 std::shared_ptr<Region> Network::addRegion(const std::string &name, const std::string &nodeType,

--- a/src/htm/engine/Network.cpp
+++ b/src/htm/engine/Network.cpp
@@ -27,7 +27,6 @@ Implementation of the Network class
 #include <htm/engine/Input.hpp>
 #include <htm/engine/Link.hpp>
 #include <htm/engine/Network.hpp>
-#include <htm/engine/NuPIC.hpp> // for register/unregister
 #include <htm/engine/Output.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/engine/RegionImplFactory.hpp>
@@ -43,12 +42,10 @@ class RegisteredRegionImpl;
 
 Network::Network() {
   commonInit();
-  NuPIC::registerNetwork(this);
 }
 
 Network::Network(const std::string& filename) {
   commonInit();
-  NuPIC::registerNetwork(this);
   loadFromFile(filename);
 }
 
@@ -58,35 +55,11 @@ void Network::commonInit() {
   iteration_ = 0;
   minEnabledPhase_ = 0;
   maxEnabledPhase_ = 0;
-  // automatic initialization of NuPIC, so users don't
-  // have to call NuPIC::initialize
-  NuPIC::init();
 }
 
 Network::~Network() {
-  NuPIC::unregisterNetwork(this);
-  /**
-   * Teardown choreography:
-   * - unintialize all regions because otherwise we won't be able to disconnect
-   * - remove all links, because we can't delete connected regions
-   *   This also removes Input and Output objects.
-   * - delete the regions themselves.
-   */
+  // The regions are deleted when the map goes out of scope.
 
-  // 1. uninitialize
-  for(auto p: regions_) {
-    std::shared_ptr<Region> r = p.second;
-    r->uninitialize();
-  }
-
-  // 2. remove all links
-  for(auto p: regions_) {
-    std::shared_ptr<Region> r = p.second;
-    r->removeAllIncomingLinks();
-  }
-
-  // 3. delete the regions
-  // They are in Shared_ptr so no need to delete regions.
 }
 
 std::shared_ptr<Region> Network::addRegion(const std::string &name, const std::string &nodeType,
@@ -263,7 +236,7 @@ std::shared_ptr<Link> Network::link(const std::string &srcRegionName,
     outputName = srcSpec->getDefaultOutputName();
   }
 
-  Output *srcOutput = srcRegion->getOutput(outputName);
+  std::shared_ptr<Output> srcOutput = srcRegion->getOutput(outputName);
   if (srcOutput == nullptr)
     NTA_THROW << "Network::link -- output " << outputName
               << " does not exist on region " << srcRegionName;
@@ -274,7 +247,7 @@ std::shared_ptr<Link> Network::link(const std::string &srcRegionName,
     inputName = destSpec->getDefaultInputName();
   }
 
-  Input *destInput = destRegion->getInput(inputName);
+  std::shared_ptr<Input> destInput = destRegion->getInput(inputName);
   if (destInput == nullptr) {
     NTA_THROW << "Network::link -- input '" << inputName
               << " does not exist on region " << destRegionName;
@@ -313,7 +286,7 @@ void Network::removeLink(const std::string &srcRegionName,
   else
     inputName = destInputName;
 
-  Input *destInput = destRegion->getInput(inputName);
+  std::shared_ptr<Input> destInput = destRegion->getInput(inputName);
   if (destInput == nullptr) {
     NTA_THROW << "Network::unlink -- input '" << inputName
               << " does not exist on region " << destRegionName;
@@ -637,7 +610,7 @@ std::ostream &operator<<(std::ostream &f, const Network &n) {
   f << "Links: [\n";
   for(auto iter = n.regions_.cbegin(); iter != n.regions_.cend(); ++iter) {
     std::shared_ptr<Region> r = iter->second;
-    const std::map<std::string, Input*> inputs = r->getInputs();
+    const std::map<std::string, std::shared_ptr<Input>> inputs = r->getInputs();
     for (const auto & inputs_input : inputs)
     {
       const std::vector<std::shared_ptr<Link>>& links = inputs_input.second->getLinks();

--- a/src/htm/engine/Network.hpp
+++ b/src/htm/engine/Network.hpp
@@ -58,18 +58,21 @@ public:
 
   /**
    *
-   * Create an new Network and register it to NuPIC.
+   * Create an new Network
    *
-   * @note Creating a Network will auto-initialize NuPIC.
+   * @Note if the Network object gets copied it does not do a
+   *       deep copy.  So both copies point to the same set of
+   *       regions and links.  The last Network object to go 
+   *       out-of-scope will delete the regions and links.
    */
   Network();
   Network(const std::string& filename);
 
-  /**
-   * Cannot copy or assign a Network object.
+  /*
+   * @Note: the pickle functions in the python bindings
+   *        require that the Network object be copyable.
+   *        The default copy constructor is ok.
    */
-  Network(const Network&) = delete;
-  void operator=(const Network&) = delete;
 
   /**
    * Destructor.

--- a/src/htm/engine/Output.cpp
+++ b/src/htm/engine/Output.cpp
@@ -34,13 +34,6 @@ Output::Output(Region* region, const std::string& outputName, NTA_BasicType type
   data_ = Array(type);
 }
 
-Output::~Output() noexcept(false) {
-  // If we have any outgoing links, then there has been an
-  // error in the shutdown process. Not good to thow an exception
-  // from a destructor, but we need to catch this error, and it
-  // should never occur if htm internal logic is correct.
-  NTA_CHECK(links_.size() == 0) << "Internal error in region deletion, still has links.";
-}
 
 
 // allocate buffer

--- a/src/htm/engine/Output.cpp
+++ b/src/htm/engine/Output.cpp
@@ -114,7 +114,7 @@ void Output::addLink(const std::shared_ptr<Link> link) {
   links_.insert(link);
 }
 
-void Output::removeLink(std::shared_ptr<Link> link) {
+void Output::removeLink(const std::shared_ptr<Link>& link) {
   // Should only be called internally. Logic error if link not found
   const auto linkIter = links_.find(link);
   NTA_CHECK(linkIter != links_.end()) << "Link not found.";

--- a/src/htm/engine/Output.hpp
+++ b/src/htm/engine/Output.hpp
@@ -48,15 +48,8 @@ public:
    *        The type of the output
    */
   Output(Region* region,
-         const std::string& outputName,
-         NTA_BasicType type);
+         const std::string& outputName, NTA_BasicType type);
 
-  /**
-   * Destructor
-   * noexcept(false) : as C++11 forces noexcept(true) in destructors by default,
-   * we override that here to throw NTA_CHECK
-   */
-  ~Output() noexcept(false);
 
   /**
    * Set the name for the output.

--- a/src/htm/engine/Output.hpp
+++ b/src/htm/engine/Output.hpp
@@ -108,7 +108,7 @@ public:
    * @param link
    *        The Link to remove
    */
-  void removeLink(std::shared_ptr<Link> link);
+  void removeLink(const std::shared_ptr<Link>& link);
 
   /**
    * Tells whether the output has outgoing links.
@@ -172,7 +172,7 @@ public:
   /**
    * Set dimensions for this output
    */
-  void setDimensions(const Dimensions& dim) { dim_ = std::move(dim); }
+  void setDimensions(const Dimensions& dim) { dim_ = dim; }
 
   /**
    *  Print raw data...for debugging

--- a/src/htm/engine/Region.cpp
+++ b/src/htm/engine/Region.cpp
@@ -27,6 +27,7 @@ Methods related to inputs and outputs are in Region_io.cpp
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <memory>
 
 #include <htm/engine/Input.hpp>
 #include <htm/engine/Output.hpp>
@@ -79,7 +80,7 @@ void Region::createInputsAndOutputs_() {
     const std::pair<std::string, OutputSpec> &p = spec_->outputs.getByIndex(i);
     const std::string& outputName = p.first;
     const OutputSpec &os = p.second;
-    auto output = std::make_shared<Output>(this, outputName, os.dataType);
+    std::shared_ptr<Output> output = std::make_shared<Output>(this, outputName, os.dataType);
     outputs_[outputName] = output;
   }
 

--- a/src/htm/engine/Region.cpp
+++ b/src/htm/engine/Region.cpp
@@ -79,7 +79,7 @@ void Region::createInputsAndOutputs_() {
     const std::pair<std::string, OutputSpec> &p = spec_->outputs.getByIndex(i);
     const std::string& outputName = p.first;
     const OutputSpec &os = p.second;
-    auto output = new Output(this, outputName, os.dataType);
+    auto output = std::make_shared<Output>(this, outputName, os.dataType);
     outputs_[outputName] = output;
   }
 
@@ -89,7 +89,7 @@ void Region::createInputsAndOutputs_() {
     const std::string& inputName = p.first;
     const InputSpec &is = p.second;
 
-    Input* input = new Input(this, inputName, is.dataType);
+    auto input = std::make_shared<Input>(this, inputName, is.dataType);
     inputs_[inputName] = input;
   }
 }
@@ -106,15 +106,8 @@ bool Region::hasOutgoingLinks() const {
 Region::~Region() {
   if (initialized_)
     uninitialize();
-
-  // If there are any links connected to our outputs, this should fail.
-  // We catch this error in the Network class and give the
-  // user a good error message (regions may be removed either in
-  // Network::removeRegion or Network::~Network())
-  for (auto &elem : outputs_) {
-    delete elem.second;
-    elem.second = nullptr;
-  }
+    
+  removeAllIncomingLinks();  // Note: link objects are stored on the Input object.
   outputs_.clear();
 
   clearInputs(); // just in case there are some still around.
@@ -126,11 +119,9 @@ void Region::clearInputs() {
   for (auto &input : inputs_) {
     auto &links = input.second->getLinks();
     for (auto &link : links) {
-      	link->getSrc().removeLink(link); // remove it from the Output object.
+      	link->getSrc()->removeLink(link); // remove it from the Output object.
     }
-	links.clear();
-    delete input.second; // This is an Input object. Its destructor deletes the links.
-    input.second = nullptr;
+	  links.clear();
   }
   inputs_.clear();
 }
@@ -238,7 +229,7 @@ Dimensions Region::getInputDimensions(std::string name) const {
   if (name.empty()) {
     name = spec_->getDefaultOutputName();
   }
-  Input* in = getInput(name);
+  std::shared_ptr<Input> in = getInput(name);
   NTA_CHECK(in != nullptr)
     << "Unknown input (" << name << ") requested on " << name_;
   return in->getDimensions();
@@ -247,7 +238,7 @@ Dimensions Region::getOutputDimensions(std::string name) const {
   if (name.empty()) {
     name = spec_->getDefaultOutputName();
   }
-  Output* out = getOutput(name);
+  std::shared_ptr<Output> out = getOutput(name);
   NTA_CHECK(out != nullptr)
     << "Unknown output (" << name << ") requested on " << name_;
   return out->getDimensions();
@@ -257,7 +248,7 @@ void Region::setInputDimensions(std::string name, const Dimensions& dim) {
   if (name.empty()) {
     name = spec_->getDefaultOutputName();
   }
-  Input* in = getInput(name);
+  std::shared_ptr<Input> in = getInput(name);
   NTA_CHECK(in != nullptr)
     << "Unknown input (" << name << ") requested on " << name_;
   return in->setDimensions(dim);
@@ -266,7 +257,7 @@ void Region::setOutputDimensions(std::string name, const Dimensions& dim) {
   if (name.empty()) {
     name = spec_->getDefaultOutputName();
   }
-  Output* out = getOutput(name);
+  std::shared_ptr<Output> out = getOutput(name);
   NTA_CHECK(out != nullptr)
     << "Unknown output (" << name << ") requested on " << name_;
   return out->setDimensions(dim);
@@ -392,14 +383,14 @@ bool Region::operator==(const Region &o) const {
 
 // Internal methods called by RegionImpl.
 
-Output *Region::getOutput(const std::string &name) const {
+std::shared_ptr<Output> Region::getOutput(const std::string &name) const {
   auto o = outputs_.find(name);
   if (o == outputs_.end())
     return nullptr;
   return o->second;
 }
 
-Input *Region::getInput(const std::string &name) const {
+std::shared_ptr<Input> Region::getInput(const std::string &name) const {
   auto i = inputs_.find(name);
   if (i == inputs_.end())
     return nullptr;
@@ -407,11 +398,11 @@ Input *Region::getInput(const std::string &name) const {
 }
 
 // Called by Network during serialization
-const std::map<std::string, Input *> &Region::getInputs() const {
+const std::map<std::string, std::shared_ptr<Input>> &Region::getInputs() const {
   return inputs_;
 }
 
-const std::map<std::string, Output *> &Region::getOutputs() const {
+const std::map<std::string, std::shared_ptr<Output>> &Region::getOutputs() const {
   return outputs_;
 }
 
@@ -440,7 +431,7 @@ void Region::setInputData(const std::string &inputName, const Array& data) {
   if (ii == inputs_.end())
     NTA_THROW << "setInputData -- unknown input '" << inputName << "' on region "
               << getName();
-  Input *in = ii->second;
+  std::shared_ptr<Input> in = ii->second;
 	in->setDimensions( { (UInt)data.getCount() } );
   Array& a = in->getData();
 	data.convertInto(a);

--- a/src/htm/engine/Region.hpp
+++ b/src/htm/engine/Region.hpp
@@ -423,13 +423,13 @@ public:
   bool isInitialized() const { return initialized_; }
 
   // Used by RegionImpl to get inputs/outputs
-  Output *getOutput(const std::string &name) const;
+  std::shared_ptr<Output> getOutput(const std::string &name) const;
 
-  Input *getInput(const std::string &name) const;
+  std::shared_ptr<Input> getInput(const std::string &name) const;
 
-  const std::map<std::string, Input *> &getInputs() const;
+  const std::map<std::string, std::shared_ptr<Input>> &getInputs() const;
 
-  const std::map<std::string, Output *> &getOutputs() const;
+  const std::map<std::string, std::shared_ptr<Output>> &getOutputs() const;
 
   void clearInputs();
 
@@ -560,8 +560,8 @@ private:
   std::string type_;
   std::shared_ptr<Spec> spec_;
 
-  typedef std::map<std::string, Output *> OutputMap;
-  typedef std::map<std::string, Input *> InputMap;
+  typedef std::map<std::string, std::shared_ptr<Output>> OutputMap;
+  typedef std::map<std::string, std::shared_ptr<Input>> InputMap;
 
   OutputMap outputs_;
   InputMap inputs_;

--- a/src/htm/engine/RegionImpl.cpp
+++ b/src/htm/engine/RegionImpl.cpp
@@ -238,11 +238,11 @@ std::string RegionImpl::executeCommand(const std::vector<std::string> &args,Int6
 
 // Provide data access for subclasses
 
-Input *RegionImpl::getInput(const std::string &name) const {
+std::shared_ptr<Input> RegionImpl::getInput(const std::string &name) const {
   return region_->getInput(name);
 }
 
-Output *RegionImpl::getOutput(const std::string &name) const {
+std::shared_ptr<Output> RegionImpl::getOutput(const std::string &name) const {
   return region_->getOutput(name);
 }
 Dimensions RegionImpl::getInputDimensions(const std::string &name) const {

--- a/src/htm/engine/RegionImpl.hpp
+++ b/src/htm/engine/RegionImpl.hpp
@@ -333,8 +333,8 @@ protected:
   // These methods provide access to inputs and outputs
   // They raise an exception if the named input or output is
   // not found.
-  Input *getInput(const std::string &name) const;
-  Output *getOutput(const std::string &name) const;
+  std::shared_ptr<Input> getInput(const std::string &name) const;
+  std::shared_ptr<Output> getOutput(const std::string &name) const;
   Dimensions getInputDimensions(const std::string &name="") const;
   Dimensions getOutputDimensions(const std::string &name="") const;
 

--- a/src/htm/engine/Watcher.hpp
+++ b/src/htm/engine/Watcher.hpp
@@ -96,7 +96,7 @@ private:
         UInt32 watchID; // starts at 1
         std::string varName;
         watcherType wType;
-        Output *output;
+        std::shared_ptr<Output> output;
         // Need regionName because we create data structure before
         // we have the actual Network to attach it to.
         std::string regionName;

--- a/src/htm/regions/SPRegion.cpp
+++ b/src/htm/regions/SPRegion.cpp
@@ -84,7 +84,7 @@ SPRegion::~SPRegion() {}
 
 void SPRegion::initialize() {
   // Output buffers should already have been created diring initialize or deserialize.
-  Output *out = getOutput("bottomUpOut");
+  std::shared_ptr<Output> out = getOutput("bottomUpOut");
   Array &outputBuffer = out->getData();
   NTA_CHECK(outputBuffer.getType() == NTA_BasicType_SDR);
   UInt32 columnCount = (UInt32)outputBuffer.getCount();
@@ -98,7 +98,7 @@ void SPRegion::initialize() {
   //
   // If there are more than one input link (FAN-IN), the input buffer will be the
   // concatination of all incomming buffers.  
-  Input *in = getInput("bottomUpIn");
+  std::shared_ptr<Input> in = getInput("bottomUpIn");
   NTA_CHECK(in != nullptr);
   if (!in->hasIncomingLinks())
      NTA_THROW << "SPRegion::initialize - No input links were configured for this SP region.\n";

--- a/src/htm/regions/TMRegion.cpp
+++ b/src/htm/regions/TMRegion.cpp
@@ -126,7 +126,7 @@ void TMRegion::initialize() {
   // If there are more than one input link, the input buffer will be the
   // concatination of all incomming buffers. This width sets the number
   // columns for the TM.
-  Input* in = region_->getInput("bottomUpIn");
+  std::shared_ptr<Input> in = region_->getInput("bottomUpIn");
   if (!in || !in->hasIncomingLinks())
       NTA_THROW << "TMRegion::initialize - No input was provided.\n";
   NTA_ASSERT(in->getData().getType() == NTA_BasicType_SDR);
@@ -196,7 +196,7 @@ void TMRegion::compute() {
 
   // Check the input buffer
   // The buffer width is the number of columns.
-  Input *in = getInput("bottomUpIn");
+  std::shared_ptr<Input> in = getInput("bottomUpIn");
   Array &bottomUpIn = in->getData();
   NTA_ASSERT(bottomUpIn.getType() == NTA_BasicType_SDR);
   SDR& activeColumns = bottomUpIn.getSDR();
@@ -228,7 +228,7 @@ void TMRegion::compute() {
   //       - The total number of elements in the outputs must be
   //         numberOfCols * cellsPerColumn.
   //
-  Output *out;
+  std::shared_ptr<Output> out;
   out = getOutput("bottomUpOut");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();

--- a/src/htm/regions/TestNode.hpp
+++ b/src/htm/regions/TestNode.hpp
@@ -200,8 +200,8 @@ private:
   size_t nodeCount_;
 
   // Input/output buffers for the whole region
-  Input *bottomUpIn_;   // required
-  Output *bottomUpOut_; // required
+  std::shared_ptr<Input> bottomUpIn_;   // required
+  std::shared_ptr<Output> bottomUpOut_; // required
 };
 } // namespace htm
 

--- a/src/htm/regions/VectorFileEffector.cpp
+++ b/src/htm/regions/VectorFileEffector.cpp
@@ -57,7 +57,7 @@ VectorFileEffector::~VectorFileEffector() { closeFile(); }
 void VectorFileEffector::initialize() {
   NTA_CHECK(region_ != nullptr);
   // We have no outputs or parameters; just need our input.
-  Input *in = region_->getInput("dataIn");
+  std::shared_ptr<Input> in = region_->getInput("dataIn");
   NTA_ASSERT(in) << "VectorFileEffector::init - 'dataIn' input not configured\n";
 
   if (!in->hasIncomingLinks() || in->getData().getCount() == 0) {

--- a/src/htm/types/Serializable.hpp
+++ b/src/htm/types/Serializable.hpp
@@ -222,12 +222,6 @@ public:
   Serializable() {}
   virtual inline int getSerializableVersion() const { return SERIALIZABLE_VERSION; }
 
-	// TODO:Cereal- after all serialization using Cereal is complete,
-  //       remove save() and load() pairs from all derived classes
-	//       change saveToStream_ar()   to save()
-  //       change loadFromStream_ar() to load().
-  //       change saveToFile_ar() to saveToFile().
-  //       change loadFromFile_ar() to loadFromFile().
 
 
 

--- a/src/test/unit/engine/CppRegionTest.cpp
+++ b/src/test/unit/engine/CppRegionTest.cpp
@@ -20,7 +20,6 @@
 #include <htm/engine/Input.hpp>
 #include <htm/engine/Link.hpp>
 #include <htm/engine/Network.hpp>
-#include <htm/engine/NuPIC.hpp>
 #include <htm/engine/Output.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/engine/Spec.hpp>

--- a/src/test/unit/engine/InputTest.cpp
+++ b/src/test/unit/engine/InputTest.cpp
@@ -42,8 +42,8 @@ TEST(InputTest, BasicNetworkConstruction) {
   std::shared_ptr<Region> r2 = net.addRegion("r2", "TestNode", "");
 
   // Test constructor
-  Input* x = r1->getInput("bottomUpIn");
-  Input* y = r2->getInput("bottomUpIn");
+  std::shared_ptr<Input> x = r1->getInput("bottomUpIn");
+  std::shared_ptr<Input> y = r2->getInput("bottomUpIn");
 
   // test getRegion()
   ASSERT_EQ(r1.get(), x->getRegion());
@@ -96,7 +96,7 @@ TEST(InputTest, LinkTwoRegionsOneInput1Dmatch) {
   Dimensions d3 = region3->getDimensions();
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;
 
@@ -129,7 +129,7 @@ TEST(InputTest, LinkTwoRegionsOneInput1Dnomatch) {
   Dimensions d3 = region3->getDimensions();
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;
 
@@ -164,7 +164,7 @@ TEST(InputTest, LinkTwoRegionsOneInput4X3) {
   Dimensions d3 = region3->getDimensions();
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;
 
@@ -208,7 +208,7 @@ TEST(InputTest, LinkTwoRegionsOneInput4X4) {
   VERBOSE << "region3 region dims: " << d3 << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   VERBOSE << "region3 input dims: " << in3->getDimensions() << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;
@@ -250,7 +250,7 @@ TEST(InputTest, LinkTwoRegionsOneInput3D1) {
   VERBOSE << "region3 region dims: " << d3 << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   VERBOSE << "region3 input dims: " << in3->getDimensions() << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;
@@ -292,7 +292,7 @@ TEST(InputTest, LinkTwoRegionsOneInput3D2) {
   VERBOSE << "region3 region dims: " << d3 << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   VERBOSE << "region3 input dims: " << in3->getDimensions() << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;
@@ -335,7 +335,7 @@ TEST(InputTest, LinkTwoRegionsOneInputFlatten) {
   VERBOSE << "region3 region dims: " << d3 << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 region dimensions " << expected;
 
-  Input *in3 = region3->getInput("bottomUpIn");
+  std::shared_ptr<Input> in3 = region3->getInput("bottomUpIn");
   d3 = in3->getDimensions();
   VERBOSE << "region3 input dims: " << in3->getDimensions() << "\n";
   EXPECT_EQ(d3, expected) << "Expected region3 input dimensions " << expected;

--- a/src/test/unit/engine/LinkTest.cpp
+++ b/src/test/unit/engine/LinkTest.cpp
@@ -70,8 +70,8 @@ TEST(LinkTest, Links) {
   ASSERT_EQ(2u, d2[1]);
 
   // test getName() and setName()
-  Input *in1 = region1->getInput("bottomUpIn");
-  Input *in2 = region2->getInput("bottomUpIn");
+  std::shared_ptr<Input> in1 = region1->getInput("bottomUpIn");
+  std::shared_ptr<Input> in2 = region2->getInput("bottomUpIn");
   EXPECT_STREQ("bottomUpIn", in1->getName().c_str());
   EXPECT_STREQ("bottomUpIn", in2->getName().c_str());
   in1->setName("uselessName");
@@ -159,9 +159,9 @@ TEST(LinkTest, DelayedLink) {
   // test initialize(), which is called by net.initialize()
   net.initialize();
 
-  Input *in1   = region1->getInput("bottomUpIn");
-  Output *out1 = region1->getOutput("bottomUpOut");
-  Input *in2   = region2->getInput("bottomUpIn");
+  std::shared_ptr<Input> in1 = region1->getInput("bottomUpIn");
+  std::shared_ptr<Output> out1 = region1->getOutput("bottomUpOut");
+  std::shared_ptr<Input> in2 = region2->getInput("bottomUpIn");
 
   // test isInitialized()
   ASSERT_TRUE(in1->isInitialized());
@@ -277,9 +277,9 @@ TEST(LinkTest, DelayedLinkSerialization) {
 
   net.initialize();
 
-  Input *in1 = region1->getInput("bottomUpIn");
-  Input *in2 = region2->getInput("bottomUpIn");
-  Output *out1 = region1->getOutput("bottomUpOut");
+  std::shared_ptr<Input> in1 = region1->getInput("bottomUpIn");
+  std::shared_ptr<Input> in2 = region2->getInput("bottomUpIn");
+  std::shared_ptr<Output> out1 = region1->getOutput("bottomUpOut");
 
   // test isInitialized()
   ASSERT_TRUE(in1->isInitialized());
@@ -393,9 +393,9 @@ TEST(LinkTest, DelayedLinkSerialization) {
   auto n2region1 = net2.getRegion("region1");
   auto n2region2 = net2.getRegion("region2");
 
-  Input *n2in1 = n2region1->getInput("bottomUpIn");
-  Input *n2in2 = n2region2->getInput("bottomUpIn");
-  Output *n2out1 = n2region1->getOutput("bottomUpOut");
+  std::shared_ptr<Input> n2in1 = n2region1->getInput("bottomUpIn");
+  std::shared_ptr<Input> n2in2 = n2region2->getInput("bottomUpIn");
+  std::shared_ptr<Output> n2out1 = n2region1->getOutput("bottomUpOut");
 
   VERBOSE << "network1\n";
   VERBOSE << " in1  buffer  =" << in1->getData() << std::endl;
@@ -634,9 +634,9 @@ private:
   size_t nodeCount_;
 
   // Input/output buffers for the whole region
-  Input *feedForwardIn_;
-  Input *lateralIn_;
-  Output *out_;
+  std::shared_ptr<Input> feedForwardIn_;
+  std::shared_ptr<Input> lateralIn_;
+  std::shared_ptr<Output> out_;
 };
 
 class L4TestRegion : public TestRegionBase {
@@ -738,8 +738,8 @@ private:
   size_t nodeCount_;
 
   // Input/output buffers for the whole region
-  Input *feedbackIn_;
-  Output *out_;
+  std::shared_ptr<Input> feedbackIn_;
+  std::shared_ptr<Output> out_;
 };
 ////////////////////////////////////////////////////////
 

--- a/src/test/unit/engine/LinkTest.cpp
+++ b/src/test/unit/engine/LinkTest.cpp
@@ -900,11 +900,12 @@ TEST(LinkTest, L2L4WithDelayedLinksAndPhases) {
 
   // Initialize the network
   net.initialize();
-
-  UInt64 *r1OutBuf = (UInt64 *)(r1->getOutput("out")->getData().getBuffer());
-  UInt64 *r2OutBuf = (UInt64 *)(r2->getOutput("out")->getData().getBuffer());
-  UInt64 *r3OutBuf = (UInt64 *)(r3->getOutput("out")->getData().getBuffer());
-  UInt64 *r4OutBuf = (UInt64 *)(r4->getOutput("out")->getData().getBuffer());
+  std::shared_ptr<Output> o = r1->getOutput("out");
+  Array& a = o->getData();
+  UInt64 *r1OutBuf = (UInt64 *)a.getBuffer();
+  UInt64 *r2OutBuf = (UInt64 *)r2->getOutput("out")->getData().getBuffer();
+  UInt64 *r3OutBuf = (UInt64 *)r3->getOutput("out")->getData().getBuffer();
+  UInt64 *r4OutBuf = (UInt64 *)r4->getOutput("out")->getData().getBuffer();
 
   // ITERATION #1
   net.run(1);

--- a/src/test/unit/engine/NetworkTest.cpp
+++ b/src/test/unit/engine/NetworkTest.cpp
@@ -22,7 +22,6 @@
 #include "gtest/gtest.h"
 
 #include <htm/engine/Network.hpp>
-#include <htm/engine/NuPIC.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/ntypes/Dimensions.hpp>
 #include <htm/utils/Log.hpp>
@@ -34,32 +33,6 @@ using namespace htm;
 static bool verbose = false;
 #define VERBOSE if(verbose) std::cerr << "[          ]"
 
-
-TEST(NetworkTest, AutoInitialization) {
-
-  // Uninitialize NuPIC since this test checks auto-initialization
-  // If shutdown fails, there is probably a problem with another test which
-  // is not cleaning up its networks.
-  if (NuPIC::isInitialized())
-    NuPIC::shutdown();
-
-  ASSERT_TRUE(!NuPIC::isInitialized());
-  // creating a network should auto-initialize NuPIC
-  {
-    Network net;
-    ASSERT_TRUE(NuPIC::isInitialized());
-    std::shared_ptr<Region> l1 = net.addRegion("level1", "TestNode", "");
-
-    // Use l1 to avoid a compiler warning
-    EXPECT_STREQ("level1", l1->getName().c_str());
-
-    // Network still exists, so this should fail.
-    EXPECT_THROW(NuPIC::shutdown(), std::exception);
-  }
-  // net destructor has been called so we should be able to shut down NuPIC now
-  NuPIC::shutdown();
-  
-}
 
 TEST(NetworkTest, RegionAccess) {
   Network net;

--- a/src/test/unit/engine/WatcherTest.cpp
+++ b/src/test/unit/engine/WatcherTest.cpp
@@ -25,7 +25,6 @@
 #include <string>
 
 #include <htm/engine/Network.hpp>
-#include <htm/engine/NuPIC.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/ntypes/Dimensions.hpp>
 #include <htm/os/Path.hpp>

--- a/src/test/unit/regions/RegionTestUtilities.cpp
+++ b/src/test/unit/regions/RegionTestUtilities.cpp
@@ -271,7 +271,7 @@ void checkInputOutputsAgainstSpec(std::shared_ptr<Region> region1, bool verbose)
     OutputSpec ospec = ns->outputs.getByIndex(i).second;
 
     VERBOSE << "Output \"" << name << "\" type: " << BasicType::getName(ospec.dataType) << std::endl;
-    Output *O = region1->getOutput(name);
+    std::shared_ptr<Output> O = region1->getOutput(name);
     ASSERT_TRUE(O != nullptr) << "The output obj could not be found.";
     EXPECT_TRUE(ospec.dataType == O->getData().getType())
       << "Output type for \"" << name << "\" does not match spec. "
@@ -283,7 +283,7 @@ void checkInputOutputsAgainstSpec(std::shared_ptr<Region> region1, bool verbose)
     InputSpec ispec = ns->inputs.getByIndex(j).second;
 
     VERBOSE << "Input \"" << name << "\" type: " << BasicType::getName(ispec.dataType) << std::endl;
-    Input *I = region1->getInput(name);
+    std::shared_ptr<Input> I = region1->getInput(name);
     ASSERT_TRUE(I != nullptr) << "The input obj could not be found.";
     if (I->isInitialized()) {
       EXPECT_TRUE(ispec.dataType == I->getData().getType())

--- a/src/test/unit/regions/SPRegionTest.cpp
+++ b/src/test/unit/regions/SPRegionTest.cpp
@@ -35,7 +35,6 @@
   */
 
 
-#include <htm/engine/NuPIC.hpp>
 #include <htm/engine/Network.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/engine/Spec.hpp>

--- a/src/test/unit/regions/TMRegionTest.cpp
+++ b/src/test/unit/regions/TMRegionTest.cpp
@@ -41,7 +41,6 @@
 #include <htm/engine/Input.hpp>
 #include <htm/engine/Link.hpp>
 #include <htm/engine/Network.hpp>
-#include <htm/engine/NuPIC.hpp>
 #include <htm/engine/Output.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/engine/RegisteredRegionImplCpp.hpp>

--- a/src/test/unit/regions/VectorFileTest.cpp
+++ b/src/test/unit/regions/VectorFileTest.cpp
@@ -34,7 +34,6 @@
   */
 
 
-#include <htm/engine/NuPIC.hpp>
 #include <htm/engine/Network.hpp>
 #include <htm/engine/Region.hpp>
 #include <htm/engine/Spec.hpp>


### PR DESCRIPTION
While working on the pickle problem I ran into a difficulty with the raw pointers used to reference the Input and Output objects in NetworkAPI.  I decided to convert them to shared_ptrs.  Rather than clutter up the pickle fix PR I broke this out into a separate PR.

So a lot of files are touched but all they do is replace the raw pointers to shared_ptrs.
Oh, and I removed the NuPIC class since it is not used for anything.

The consequences of this PR are that it does break the API slightly.  These pointers are exposed in the C++ functions getInput() and getOutput() that can be called from Region implementations.  But these are not exposed in Python API's.   So the impact would be very small I would think.