### PR TITLE
Fixed that htm.advanced.regions.extractList did not like leading spaces

### DIFF
--- a/py/htm/advanced/regions/__init__.py
+++ b/py/htm/advanced/regions/__init__.py
@@ -16,6 +16,8 @@ def extractList(listString, dataType=None):
             
         except json.decoder.JSONDecodeError:
             try:
+                list_string = list_string.replace('   ', ' ')
+                list_string = list_string.replace('  ', ' ')
                 if list_string.startswith('[ '):
                     list_string = list_string.replace('[ ', '[')
                 list_string = (',').join(list_string.split(' '))
@@ -24,7 +26,12 @@ def extractList(listString, dataType=None):
             except json.decoder.JSONDecodeError:
                 list_string = list_string.replace('.,', '.0,')
                 list_string = list_string.replace('.]', '.0]')
-                data_list = json.loads(list_string)
+                try:
+                    data_list = json.loads(list_string)
+                except json.decoder.JSONDecodeError as ex:
+                    # Got something really out of bounds
+                    # Catch and then ass on as a debugging hook
+                    raise ex
                 
         if data_list:
             if dataType is None:

--- a/py/htm/advanced/regions/__init__.py
+++ b/py/htm/advanced/regions/__init__.py
@@ -1,13 +1,14 @@
 
 import json
 
-def extractList(list_string, dataType=None):
+def extractList(listString, dataType=None):
     """
     Extract a list of dataType from list_string string.
     The same separator must be used consistently in the string. Either ',' or single spaces.
     If dataType is None, just return a parsed list.
     """
     data_list = []
+    list_string = listString
     
     if list_string:
         try:
@@ -15,6 +16,8 @@ def extractList(list_string, dataType=None):
             
         except json.decoder.JSONDecodeError:
             try:
+                if list_string.startswith('[ '):
+                    list_string = list_string.replace('[ ', '[')
                 list_string = (',').join(list_string.split(' '))
                 data_list = json.loads(list_string)
                 

--- a/py/tests/advanced/regions/region_init_test.py
+++ b/py/tests/advanced/regions/region_init_test.py
@@ -104,8 +104,18 @@ class RegionInitTests(unittest.TestCase):
         self.assertEqual([20.0, -20.0], extracted_list)
         list_string = '[ 20.0, -20.0]'
         extracted_list = extractList(list_string, float)
+        list_string = '[  20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        list_string = '[   20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
         self.assertEqual([20.0, -20.0], extracted_list)
         list_string = '[-20.0,20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, 20.0], extracted_list)
+        list_string = '[-20.0, 20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, 20.0], extracted_list)
+        list_string = '[-20.0,  20.0]'
         extracted_list = extractList(list_string, float)
         self.assertEqual([-20.0, 20.0], extracted_list)
         list_string = '[ -20.0,20.0]'

--- a/py/tests/advanced/regions/region_init_test.py
+++ b/py/tests/advanced/regions/region_init_test.py
@@ -29,12 +29,18 @@ class RegionInitTests(unittest.TestCase):
         list_string = '[0, 1, 2, 3, 42]'
         extracted_list = extractList(list_string, int)
         self.assertEqual([0,1,2,3,42], extracted_list)
+        list_string = '[ 0, 1, 2, 3, 42]'
+        extracted_list = extractList(list_string, int)
+        self.assertEqual([0,1,2,3,42], extracted_list)
 
     def testExtractListFloat(self):
         """
         Test that extractList extracts floats.
         """
         list_string = '[0.0, 1.0, 2.0, 3.1, 4.2]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([0.0,1.0,2.0,3.1,4.2], extracted_list)
+        list_string = '[ 0.0, 1.0, 2.0, 3.1, 4.2]'
         extracted_list = extractList(list_string, float)
         self.assertEqual([0.0,1.0,2.0,3.1,4.2], extracted_list)
 
@@ -57,6 +63,9 @@ class RegionInitTests(unittest.TestCase):
         list_string = '[0 1 2 3 4]'
         extracted_list = extractList(list_string, int)
         self.assertEqual([0, 1, 2, 3, 4], extracted_list)
+        list_string = '[ 0 1 2 3 4]'
+        extracted_list = extractList(list_string, int)
+        self.assertEqual([0, 1, 2, 3, 4], extracted_list)
 
     def testExtractArrayFloat(self):
         """
@@ -65,12 +74,86 @@ class RegionInitTests(unittest.TestCase):
         list_string = '[0.0 1.0 2.0 3.1 4.2]'
         extracted_list = extractList(list_string, float)
         self.assertEqual([0.0, 1.0, 2.0, 3.1, 4.2], extracted_list)
+        list_string = '[ 0.0 1.0 2.0 3.1 4.2]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([0.0, 1.0, 2.0, 3.1, 4.2], extracted_list)
+
+    def testExtractNegativeFloat(self):
+        """
+        Test that extractList extracts floats from np.array string.
+        """
+        list_string = '[-20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, -20.0], extracted_list)
+        list_string = '[ -20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, -20.0], extracted_list)
+        list_string = '[-20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, -20.0], extracted_list)
+        list_string = '[ -20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, -20.0], extracted_list)
+
+    def testExtractArrayMixedSignFloat(self):
+        """
+        Test that extractList extracts floats from np.array string.
+        """
+        list_string = '[20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([20.0, -20.0], extracted_list)
+        list_string = '[ 20.0, -20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([20.0, -20.0], extracted_list)
+        list_string = '[-20.0,20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, 20.0], extracted_list)
+        list_string = '[ -20.0,20.0]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20.0, 20.0], extracted_list)
+
+    def testExtractArrayMixedSignInt(self):
+        """
+        Test that extractList extracts floats from np.array string.
+        """
+        list_string = '[20, -20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([20, -20], extracted_list)
+        list_string = '[ 20, -20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([20, -20], extracted_list)
+        list_string = '[-20, 20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20, 20], extracted_list)
+        list_string = '[ -20, 20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20, 20], extracted_list)
+
+    def testExtractArrayNegativeInt(self):
+        """
+        Test that extractList extracts floats from np.array string.
+        """
+        list_string = '[-20, -20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20, -20], extracted_list)
+        list_string = '[ -20, -20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20, -20], extracted_list)
+        list_string = '[-20,-20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20, -20], extracted_list)
+        list_string = '[ -20,-20]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([-20, -20], extracted_list)
 
     def testExtractArrayFloatNoTrailingZero(self):
         """
         Test that extractList extracts floats from np.array string.
         """
         list_string = '[0. 1. 2.]'
+        extracted_list = extractList(list_string, float)
+        self.assertEqual([0.0, 1.0, 2.0], extracted_list)
+        list_string = '[ 0. 1. 2.]'
         extracted_list = extractList(list_string, float)
         self.assertEqual([0.0, 1.0, 2.0], extracted_list)
 
@@ -89,6 +172,15 @@ class RegionInitTests(unittest.TestCase):
         list_string = '[0, 1, 2, 3, 42, [67, 89], "Hello World"]'
         extracted_list = extractList(list_string)
         self.assertEqual([0, 1, 2, 3, 42, [67, 89], "Hello World"], extracted_list)
+        list_string = '[ 0, 1, 2, 3, 42, [67, 89], "Hello World"]'
+        extracted_list = extractList(list_string)
+        self.assertEqual([0, 1, 2, 3, 42, [67, 89], "Hello World"], extracted_list)
+        list_string = '[ 0, 1, 2, 3, 42, [ 67, 89], "Hello World"]'
+        extracted_list = extractList(list_string)
+        self.assertEqual([0, 1, 2, 3, 42, [ 67, 89], "Hello World"], extracted_list)
+        list_string = '[0, 1, 2, 3, 42, [ 67, 89], "Hello World"]'
+        extracted_list = extractList(list_string)
+        self.assertEqual([0, 1, 2, 3, 42, [ 67, 89], "Hello World"], extracted_list)
 
     def testAsBool(self):
         """"


### PR DESCRIPTION
after the leading square bracket in strings of lists.
Added unit tests to check this.
The bindings seem to have a mind of their own where insret spaces is concerned.
A better solution to handle all this would be to use a full fledged parser but I do not have time for that.
Hopefully these patches will hold up.