### PR TITLE
Naive implementations of optimizations suggested by breznak on pull-request n. 769

### DIFF
--- a/src/htm/algorithms/SpatialPooler.hpp
+++ b/src/htm/algorithms/SpatialPooler.hpp
@@ -1108,6 +1108,9 @@ public:
   */
   bool isUpdateRound_() const;
 
+  void calculateWrapAroundNeighbors();
+  void mapAllNeighbors();
+
   //-------------------------------------------------------------------
   // Debugging helpers
   //-------------------------------------------------------------------
@@ -1141,6 +1144,8 @@ protected:
   Real localAreaDensity_;
   UInt stimulusThreshold_;
   UInt inhibitionRadius_;
+  UInt wrapAroundNeighbors_;
+  vector<UInt> neighborMap_;
   UInt dutyCyclePeriod_;
   Real boostStrength_;
   UInt iterationNum_;


### PR DESCRIPTION
With regards to the optimizations suggested by breznak toward the end of pull-request n. 769 ( https://github.com/htm-community/htm.core/pull/769#issuecomment-589182167 and subsequent posts), I've added naive implementations of the caching of numNeigbors (in wrapping neighborhoods) and of the caching of all the neighbors of each column (in wrapping neighborhoods).

My results are as follows: **NOTE: I'm still only using dynamic_hotgym as a benchmark, and haven't looked at mnist_sp yet**

- Caching of numNeighbors resulted in a a drop of ~6.5% in total time spent in local inhibition (as compared to the original run time);
- Caching of all neighbors of columns, when applied only to inhibitColumnsLocal_(), resulted in a drop of ~14% in total time spent in local inhibition (as compared to the original run time);
- (*)Caching of all neighbors of columns, when applied to updateBoostFactorsLocal_(), resulted in a drop of ~55% in total time spent in local inhibition (as compared to the original run time).

(*) It should be noted that in dynamic_hotgym, updateBoostFactorsLocal_() could be skipped completely, as boostFactor_ is always = 0. However, I don't believe this has any bearing on the results.

I forgot to keep track of memory usage, but I did some back of hand calculations and figured it shouldn't be so bad if you have man GB of RAM and don't go over 10k columns.  Maybe this speed/memory trade-off could be added as an option, instead of as mandatory usage?

Thanks again breznak.