### PR TITLE
GCC 9 / ubuntu 20.04 support 

### DIFF
--- a/bindings/py/packaging/dummy.c
+++ b/bindings/py/packaging/dummy.c
@@ -1,14 +1,14 @@
 #include <stdio.h>
 #include <Python.h>
 
-int main()
+int main(void)
 {
     return 0;
 }
 
 #if PY_MAJOR_VERSION >= 3
-void PyInit_dummy() {}
+void PyInit_dummy(void) {}
 #else
-void initdummy() {}
+void initdummy(void) {}
 #endif
 


### PR DESCRIPTION
used in Ubuntu 20.04, Wstrict-prototypes
just warning

- [x] GCC 9 compatibility 
- [x] python 3.8