### PR TITLE
CI cibuildwheel invalid syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,11 +88,10 @@ jobs:
         CIBW_TEST_COMMAND: "pytest py/tests bindings/py/tests"
         # Only build on Python >=3.7 and skip 32-bit builds
         CIBW_BUILD: cp3?-*
-        CIBW_SKIP: "*-win32"
+        CIBW_SKIP: "*-win32 cp27-manylinux*"
         # build using the manylinux2014 image
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-        CIBW_SKIP: cp27-manylinux*
       run: |
         python -m cibuildwheel --output-dir wheelhouse
 


### PR DESCRIPTION
the same env: variable cannot be set twice, fix.