### PR TITLE
CI: publish pypi using download artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,10 +101,48 @@ jobs:
         name: wheels
         path: ./wheelhouse
 
+
+
+  publish-pypi: #this is a separate job, as the upload must run only once, and when all wheels are created
+    needs: [build-release-gh]
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: actions/download-artifact@master
+      with:
+        name: wheels
+        path: dist/
+
+        #    - uses: actions/download-artifact@master
+        #      with:
+        #        name: dist-macOs-latest
+        #        path: dist/
+
+        #    - uses: actions/download-artifact@master
+        #      with:
+        #        name: dist-windows-2019
+        #        path: dist/
+
+        #    - uses: actions/download-artifact@master
+        #        with:
+        #        name: dist-arm64
+        #        path: dist/
+
+    - name: pre-PyPI
+      #copy dist data to /dist, where PyPI Action expects it
+      run: |
+        cd dist
+        ls -lh
+        rm *.egg #remove obsoleted egg format
+        rm requirements.txt # PIPY upload has problem with non-*.whl files
+        cd ..
+        ls dist/
+
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
         repository_url: https://test.pypi.org/legacy/ #TODO rm for real pypi
-        packages_dir: ./wheelhouse/
+        packages_dir: ./dist/


### PR DESCRIPTION
gh-action-publish-pypi runs only on Linux,
so we need to use upload artifact on each platform,
then spin an ubuntu image and download all artifacts,
and publish them once to PyPI