### PR TITLE
CI: separate builds for GH Release and PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,17 @@ jobs:
         name: "dist-${{ matrix.os }}"
         path: build/Release/distr/dist
 
+
+
+  build-wheels:
+    name: Wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      #max-parallel: 4
+      matrix:
+        python-version: [3.7] #other pythons are internally changed by CIBW
+        os: [ubuntu-18.04, windows-2019, macOS-latest]
+    steps:
     - name: Install cibuildwheel
       run: |
         python -m pip install cibuildwheel==1.4.2
@@ -104,7 +115,7 @@ jobs:
 
 
   publish-pypi: #this is a separate job, as the upload must run only once, and when all wheels are created
-    needs: [build-release-gh]
+    needs: [build-wheels]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
as the PyPI is run by CIBW, and must use clean dir.
To GH Release we publish CI platform builds.