### PR TITLE
create network with a custom id when force param is set

### DIFF
--- a/src/examples/rest/server_core.hpp
+++ b/src/examples/rest/server_core.hpp
@@ -87,7 +87,7 @@ public:
     }
 
 
-    //  POST /network?id=<previous id>
+    //  POST /network?id=<previous id>&force
     //  Configure a Network resource (with JSON configuration in POST body) ==> token
     //  Note: the id parameter is optional.  If given it will re-use (replace) a previous id.
     svr.Post("/network", [&](const Request &req, Response &res) {
@@ -95,8 +95,14 @@ public:
       auto itr = req.params.find("id");
       if (itr != req.params.end())
         id = itr->second;
+
+      bool force = false;
+      itr = req.params.find("force");
+      if (itr != req.params.end())
+        force = true;
+
       RESTapi *interface = RESTapi::getInstance();
-      std::string token = interface->create_network_request(id, req.body);
+      std::string token = interface->create_network_request(id, req.body, force);
       res.set_content(token+"\n", "text/plain");
     });
     

--- a/src/examples/rest/server_core.hpp
+++ b/src/examples/rest/server_core.hpp
@@ -87,22 +87,17 @@ public:
     }
 
 
-    //  POST /network?id=<previous id>&force
+    //  POST /network?id=<previous id>
     //  Configure a Network resource (with JSON configuration in POST body) ==> token
-    //  Note: the id parameter is optional.  If given it will re-use (replace) a previous id.
+    //  Note: the id parameter is optional.  If given it will re-use (replace) a previous id or use it.
     svr.Post("/network", [&](const Request &req, Response &res) {
       std::string id;
       auto itr = req.params.find("id");
       if (itr != req.params.end())
         id = itr->second;
 
-      bool force = false;
-      itr = req.params.find("force");
-      if (itr != req.params.end())
-        force = true;
-
       RESTapi *interface = RESTapi::getInstance();
-      std::string token = interface->create_network_request(id, req.body, force);
+      std::string token = interface->create_network_request(id, req.body);
       res.set_content(token+"\n", "text/plain");
     });
     

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -64,9 +64,12 @@ std::string RESTapi::get_new_id_(const std::string &old_id) {
 
 
 
-std::string RESTapi::create_network_request(const std::string &old_id, const std::string &config) {
+std::string RESTapi::create_network_request(const std::string &old_id, const std::string &config, bool force) {
   try {
-    std::string id = get_new_id_(old_id);
+    std::string id = old_id;
+    if (!force) {
+      id = get_new_id_(old_id);
+    }
     ResourceContext obj;
     obj.id = id;
     obj.t = time(0);

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -39,10 +39,10 @@ RESTapi* RESTapi::getInstance() { return &rest; }
 std::string RESTapi::get_new_id_(const std::string &old_id) {
   std::string id = old_id;
 
-  // re-use the same id if we can.
-  std::map<std::string, ResourceContext>::iterator itr = resource_.find(old_id);
-  if (itr == rest.resource_.end()) {
-    // not found, create a new context id
+  // re-use the same id if we can or use a provide one.
+  std::map<std::string, ResourceContext>::iterator itr;
+  if (id.empty()) {
+    // id is empty, create a new context id
     while (rest.resource_.size() < UINT16_MAX - 1) {
       unsigned int id_nbr = next_id++;
       if (id_nbr == 0)
@@ -64,12 +64,9 @@ std::string RESTapi::get_new_id_(const std::string &old_id) {
 
 
 
-std::string RESTapi::create_network_request(const std::string &old_id, const std::string &config, bool force) {
+std::string RESTapi::create_network_request(const std::string &old_id, const std::string &config) {
   try {
-    std::string id = old_id;
-    if (!force) {
-      id = get_new_id_(old_id);
-    }
+    std::string id = get_new_id_(old_id);
     ResourceContext obj;
     obj.id = id;
     obj.t = time(0);

--- a/src/htm/engine/RESTapi.hpp
+++ b/src/htm/engine/RESTapi.hpp
@@ -89,7 +89,7 @@ public:
   * @retval On success it returns the id to use with this resource context. 
   *         Otherwise it returns the error message starting with "ERROR".
   */
-  std::string create_network_request(const std::string &id, const std::string &conf, bool force);
+  std::string create_network_request(const std::string &id, const std::string &conf);
 
   /**
    * @b Description:

--- a/src/htm/engine/RESTapi.hpp
+++ b/src/htm/engine/RESTapi.hpp
@@ -89,7 +89,7 @@ public:
   * @retval On success it returns the id to use with this resource context. 
   *         Otherwise it returns the error message starting with "ERROR".
   */
-  std::string create_network_request(const std::string &id, const std::string &conf);
+  std::string create_network_request(const std::string &id, const std::string &conf, bool force);
 
   /**
    * @b Description:


### PR DESCRIPTION
In my situation I use htm.core rest_server to predict and anomly the temperature which from real temperature sensor.

The sensor on my iot platform has an unique id, which can be an network id.

If i has 1000 sensor,  on the old way i create a table which contain unique id and network id.
when the rest_server restart the network id is reset,  then the unique id and network id map is failure.