### PR TITLE
Allowed variation in POST, added unit test

### DIFF
--- a/src/examples/rest/server_core.hpp
+++ b/src/examples/rest/server_core.hpp
@@ -28,7 +28,7 @@
 //     or
 //       /network?id=<id>
 //       Create a new Network class object as a resource identified by id.
-//       The id field is optional. If the id is given the new network object will be 
+//       The id field is optional. If the id is given the new network object will be
 //       assigned to this id.  Otherwise it will be assigned to the next available id.
 //       The body of the POST is JSON formatted configuration string
 //       Returns the id for the created resouce or an Error message.
@@ -61,18 +61,18 @@
 //       Stop the server.  All resources are released.
 
 #include <cctype>
+#include <chrono>
+#include <cstdio>
+#include <htm/engine/Network.hpp>
+#include <htm/engine/RESTapi.hpp>
+#include <httplib.h>
 #include <iomanip>
 #include <sstream>
 #include <string>
-#include <chrono>
-#include <cstdio>
-#include <httplib.h>
-#include <htm/engine/Network.hpp>
-#include <htm/engine/RESTapi.hpp>
 
 #define SERVER_CERT_FILE "./cert.pem"
 #define SERVER_PRIVATE_KEY_FILE "./key.pem"
-#define DEFAULT_PORT 8050  // default port to listen on
+#define DEFAULT_PORT 8050 // default port to listen on
 #define DEFAULT_INTERFACE "127.0.0.1"
 
 using namespace httplib;
@@ -80,20 +80,16 @@ using namespace htm;
 
 class RESTserver {
 
-
 public:
   RESTserver() {
-    
+
     /*** Register all of the handlers ***/
 
     //  GET  /hi    ==>  "Hello World!\n"
-    svr.Get("/hi", [](const Request & /*req*/, Response &res) { 
-      res.set_content("Hello World!\n", "text/plain"); 
-      });
+    svr.Get("/hi", [](const Request & /*req*/, Response &res) { res.set_content("Hello World!\n", "text/plain"); });
     if (!svr.is_valid()) {
       NTA_THROW << "server could not be created...\n";
     }
-
 
     //  POST /network?id=<specified id>
     // or
@@ -103,34 +99,33 @@ public:
     //  Create and configure a Network resource indexed by an id.
     //  The configuration string is passed in the POST body, JSON encoded.
     //  Returns the id used (URLencoded).  Subsequent calls should use this id.
-    //  Note: the id parameter is optional.  If not provided it will use the next 
+    //  Note: the id parameter is optional.  If not provided it will use the next
     //        available id.  Otherwise it will use and return the specified id.
     //        If a Network object is already associated with the specified id
     //        the program will remove the existing Network object and create a new one.
     //
-    //        The specified id does not have to be numeric.  However, if it is 
+    //        The specified id does not have to be numeric.  However, if it is
     //        not compatible with URL syntax the returned id will be a URLencoded
     //        copy of the id.
     //
     svr.Post("/network", [&](const Request &req, Response &res) {
-      std::string id;      
+      std::string id;
       auto itr = req.params.find("id");
       if (itr != req.params.end())
-        id = url_encode(itr->second);  // the returned parameter value gets url decoded so must re-encode it.
-      
+        id = url_encode(itr->second); // the returned parameter value gets url decoded so must re-encode it.
+
       std::string data = res.body;
       auto ix = req.params.find("data"); // The body could optionally be encoded in a parameter
       if (ix != req.params.end())
         data = ix->second;
 
-
       RESTapi *interface = RESTapi::getInstance();
       std::string token = interface->create_network_request(id, req.body);
-      res.set_content(token+"\n", "text/plain");
+      res.set_content(token + "\n", "text/plain");
     });
     svr.Post("/network/[^/]*", [&](const Request &req, Response &res) {
       std::vector<std::string> flds = split(req.path, '/');
-      std::string id = flds[2];  
+      std::string id = flds[2];
 
       std::string data = res.body;
       auto ix = req.params.find("data");
@@ -139,10 +134,9 @@ public:
 
       RESTapi *interface = RESTapi::getInstance();
       std::string token = interface->create_network_request(id, req.body);
-      res.set_content(token+"\n", "text/plain");
+      res.set_content(token + "\n", "text/plain");
     });
 
-    
     //  PUT  /network/<id>/region/<region name>/param/<param name>?data=<JSON encoded data>
     // Set the value of a ReadWrite Parameter on a Region.  Alternatively, the data could be in the body.
     svr.Put("/network/.*/region/.*/param/.*", [&](const Request &req, Response &res) {
@@ -154,7 +148,7 @@ public:
       auto ix = req.params.find("data");
       if (ix != req.params.end())
         data = ix->second;
-      
+
       RESTapi *interface = RESTapi::getInstance();
       std::string result = interface->put_param_request(id, region_name, param_name, data);
       res.set_content(result + "\n", "text/plain");
@@ -216,7 +210,7 @@ public:
       std::string result = interface->get_output_request(id, region_name, output_name);
       res.set_content(result + "\n", "text/plain");
     });
-    
+
     //  DELETE /network/<id>/region/<region name>
     //       Deletes a region. Must not be in any links.
     svr.Delete("/network/.*/region/.*", [](const Request &req, Response &res) {
@@ -241,7 +235,7 @@ public:
       std::string result = interface->delete_link_request(id, source_name, dest_name);
       res.set_content(result + "\n", "text/plain");
     });
-    
+
     //  DELETE /network/<id>/ALL
     //       Deletes the entire Network object
     svr.Delete("/network/.*/ALL", [](const Request &req, Response &res) {
@@ -252,7 +246,6 @@ public:
       std::string result = interface->delete_network_request(id);
       res.set_content(result + "\n", "text/plain");
     });
-
 
     // GET /network/<id>/run?iterations=<iterations>
     //    Execute the NetworkAPI <iterations> times.
@@ -267,7 +260,7 @@ public:
 
       RESTapi *interface = RESTapi::getInstance();
       std::string result = interface->run_request(id, iterations);
-      res.set_content(result+"\n", "text/plain");
+      res.set_content(result + "\n", "text/plain");
     });
 
     //  GET  /network/<id>/region/<region name>/command?data=<command>
@@ -288,12 +281,9 @@ public:
       res.set_content(result + "\n", "text/plain");
     });
 
-
-
-    //  GET /stop  
+    //  GET /stop
     //    Halt the server.
-    svr.Get("/stop",  [&](const Request & /*req*/, Response & /*res*/) { svr.stop(); });
-
+    svr.Get("/stop", [&](const Request & /*req*/, Response & /*res*/) { svr.stop(); });
 
     // What to do if there is an error in the server.
     svr.set_error_handler([](const Request & /*req*/, Response &res) {
@@ -302,50 +292,46 @@ public:
       snprintf(buf, sizeof(buf), fmt, res.status);
       res.set_content(buf, "text/html");
     });
-
   }
-
 
   // How to perform logging.
-  inline void set_logger(httplib::Logger logger) {
-      svr.set_logger(logger);
-  }
+  inline void set_logger(httplib::Logger logger) { svr.set_logger(logger); }
 
   inline void listen(int port, std::string net_interface) {
-      // Enter the server listen loop.
-      svr.listen(net_interface.c_str(), port);
+    // Enter the server listen loop.
+    svr.listen(net_interface.c_str(), port);
   }
-  
 
   inline std::string url_encode(const std::string &value) {
-      std::ostringstream escaped;
-      escaped.fill('0');
-      escaped << std::hex;
+    std::ostringstream escaped;
+    escaped.fill('0');
+    escaped << std::hex;
 
-      for (std::string::const_iterator i = value.begin(), n = value.end(); i != n; ++i) {
-          std::string::value_type c = (*i);
+    for (std::string::const_iterator i = value.begin(), n = value.end(); i != n; ++i) {
+      std::string::value_type c = (*i);
 
-          // Keep alphanumeric and other accepted characters intact
-          if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
-              escaped << c;
-              continue;
-          }
-
-          // Any other characters are percent-encoded
-          escaped << std::uppercase;
-          escaped << '%' << std::setw(2) << int((unsigned char) c);
-          escaped << std::nouppercase;
+      // Keep alphanumeric and other accepted characters intact
+      if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+        escaped << c;
+        continue;
       }
 
-      return escaped.str();
+      // Any other characters are percent-encoded
+      escaped << std::uppercase;
+      escaped << '%' << std::setw(2) << int((unsigned char)c);
+      escaped << std::nouppercase;
+    }
+
+    return escaped.str();
   }
-  
+
+  inline bool is_running() { return svr.is_running(); }
+  inline void stop() { svr.stop(); }
 
 private:
-  #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-    SSLServer svr(SERVER_CERT_FILE, SERVER_PRIVATE_KEY_FILE);
-  #else
-    Server svr;
-  #endif
-  
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+  SSLServer svr(SERVER_CERT_FILE, SERVER_PRIVATE_KEY_FILE);
+#else
+  Server svr;
+#endif
 };

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -94,6 +94,7 @@ struct SynapseData: public Serializable {
     NTA_CHECK(presynapticMapIndex_ == o.presynapticMapIndex_ ) << "SynapseData equals: presynapticMapIndex_";
     NTA_CHECK(id == o.id ) << "SynapseData equals: id";
     } catch(const htm::Exception& ex) {
+      UNUSED(ex);    // this avoids the warning if ex is not used.
       //NTA_WARN << "SynapseData equals: " << ex.what(); //Note: uncomment for debug, tells you 
       //where the diff is. It's perfectly OK for the "exception" to occur, as it just denotes
       //that the data is NOT equal.
@@ -153,6 +154,7 @@ struct SegmentData: public Serializable {
       NTA_CHECK(id == o.id) << "SegmentData equals: id";
 
     } catch(const htm::Exception& ex) {
+      UNUSED(ex);    // this avoids the warning if ex is not used.
       //NTA_WARN << "SegmentData equals: " << ex.what();
       return false;
     }
@@ -192,6 +194,7 @@ struct CellData : public Serializable {
     try {
       NTA_CHECK( segments == o.segments ) << "CellData equals: segments";
     } catch(const htm::Exception& ex) {
+      UNUSED(ex);    // this avoids the warning if ex is not used.
       //NTA_WARN << "CellData equals: " << ex.what();
       return false;
     }

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -356,7 +356,7 @@ void SpatialPooler::setPermanence(UInt column, const Real permanences[]) {
 
 void SpatialPooler::getConnectedCounts(UInt connectedCounts[]) const {
   for(size_t seg = 0; seg < numColumns_; seg++) { //in SP each column = 1 cell with 1 segment only.
-    const auto &segment = connections_.dataForSegment( (const Segment)seg );
+    const auto &segment = connections_.dataForSegment( seg );
     connectedCounts[ seg ] = segment.numConnected; //TODO numConnected only used here, rm from SegmentData and compute for each segment.synapses?
   }
 }

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -356,7 +356,7 @@ void SpatialPooler::setPermanence(UInt column, const Real permanences[]) {
 
 void SpatialPooler::getConnectedCounts(UInt connectedCounts[]) const {
   for(size_t seg = 0; seg < numColumns_; seg++) { //in SP each column = 1 cell with 1 segment only.
-    const auto &segment = connections_.dataForSegment( seg );
+    const auto &segment = connections_.dataForSegment( (const Segment)seg );
     connectedCounts[ seg ] = segment.numConnected; //TODO numConnected only used here, rm from SegmentData and compute for each segment.synapses?
   }
 }

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -23,7 +23,6 @@ Implementation of the RESTapi class
 #include <htm/engine/RESTapi.hpp>
 #include <htm/engine/Network.hpp>
 
-const size_t RESOURCE_TIMEOUT = 86400; // one day
 const size_t ID_MAX = 9999; // maximum number of generated ids  (this is arbitrary)
 
 using namespace htm;
@@ -55,7 +54,7 @@ RESTapi* RESTapi::getInstance() { return &rest; }
 
     // Make sure this new session id is not in use.
     itr = resource_.find(id);
-    if (itr == resource_.end() || (itr->second.t < time(0) - RESOURCE_TIMEOUT)) {
+    if (itr == resource_.end()) {
       // This is one we can use
       break;
     }

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -24,7 +24,7 @@ Implementation of the RESTapi class
 #include <htm/engine/Network.hpp>
 
 #define RESOURCE_TIMEOUT 86400    // one day
-#define ID_MAX=9999               // maximum number of generated ids  (this is arbitrary)
+#define ID_MAX 9999               // maximum number of generated ids  (this is arbitrary)
 
 using namespace htm;
 

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -38,7 +38,9 @@ RESTapi* RESTapi::getInstance() { return &rest; }
 
   std::string RESTapi::get_new_id_() {
   // No id was provided so find the next available number.
-  // Do not use an id of "0".
+  // Note: This will return a 4 digit number as a string, 
+  //       starting with "0001" and incrementing on each use. 
+  //       This will never return "0000" 
   
   std::map<std::string, ResourceContext>::iterator itr;
   std::string id;

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -47,7 +47,7 @@ RESTapi* RESTapi::getInstance() { return &rest; }
   while (rest.resource_.size() < ID_MAX) {  // limit the total number of generated resources
     unsigned int id_nbr = next_id++;
     if (id_nbr > ID_MAX)
-      id_nbr = 1; // allow integer wrap of the id without a "0000" value.
+      id_nbr = 1; // allow integer wrap of the id without using a "0000" value.
     char buf[10];
     std::snprintf(buf, sizeof(buf), "%4.04x", id_nbr);
     id = buf;

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -24,6 +24,7 @@ Implementation of the RESTapi class
 #include <htm/engine/Network.hpp>
 
 #define RESOURCE_TIMEOUT 86400    // one day
+#define ID_MAX=9999               // maximum number of generated ids  (this is arbitrary)
 
 using namespace htm;
 
@@ -44,10 +45,10 @@ RESTapi* RESTapi::getInstance() { return &rest; }
   
   std::map<std::string, ResourceContext>::iterator itr;
   std::string id;
-  while (rest.resource_.size() < UINT16_MAX - 1) {
+  while (rest.resource_.size() < ID_MAX) {  // limit the total number of generated resources
     unsigned int id_nbr = next_id++;
-    if (id_nbr == 0)
-      id_nbr = next_id++; // allow integer wrap of the id without a 0 value.
+    if (id_nbr > ID_MAX)
+      id_nbr = 1; // allow integer wrap of the id without a "0000" value.
     char buf[10];
     std::snprintf(buf, sizeof(buf), "%4.04x", id_nbr);
     id = buf;

--- a/src/htm/engine/RESTapi.hpp
+++ b/src/htm/engine/RESTapi.hpp
@@ -36,7 +36,7 @@
  *       message should apply to. Since the protocol is stateless, the "run" 
  *       messages must carry their own state or context. That context is a 
  *       resouce id that was returned from a previous "network create"  message 
- *       that created a Network context and stashed it in resouces map
+ *       that created a Network context and stashed it in a resouces map
  *       indexed by id.
  *
  *       There is a maximum of 65535 active Network class resources.
@@ -80,8 +80,11 @@ public:
   * Handler for a "create network resource" request message.
   * This will create a new Network object for this context and configure it.
   *
-  * @param id  A client should use a id of "0" on the first call.  All subsequet calls
-  * of any message type should use the id returned by this function.
+  * @param id  The id to use for this new Network object.  If this is an empty string
+  *         the next available id will be used.  All subsequet calls
+  *         of any message type should use the id returned by this function.
+  *         NOTE: if there is already a Network object corresponding to a specified id
+  *               that Network object will be deleted and a new one created.
   *
   * @param conf  A YAML or JSON string containing the configuration for the Network class.
   *              See Network::configure() for syntax.
@@ -114,10 +117,19 @@ public:
    *                    If blank, no data is set.
    *
    * @param id          Identifier for the resource context (a Network class instance).
-   *                    Client should pass the id returned by the previous "configure"
-   *                    request message.
+   *                    Subsequent calls related to this Network object should use this id.
+   *                    Note: the id parameter can be an empty string.  If empty the program
+   *                          will use the next available id.  Otherwise it will use and 
+   *                          return the specified id.
    *
-   * @retval            If success returns "OK".
+   *                          If a Network object is already associated with the specified id
+   *                          the program will remove the existing Network object and create a new one.
+   *
+   *                          The specified id does not have to be numeric.  However, if it is 
+   *                          not compatible with URL syntax the returned id will be a URLencoded
+   *                          copy of the id.
+   *
+   * @retval            If success returns the id.
    *                    Otherwise returns error message starting with "ERROR: ".
    */
   std::string put_input_request(const std::string &id, 
@@ -354,7 +366,7 @@ private:
 
   // A map of open resources. 
   std::map<std::string, ResourceContext> resource_;
-  std::string get_new_id_(const std::string &old_id);
+  std::string get_new_id_(); 
 };
 
 } // namespace htm

--- a/src/htm/engine/RESTapi.hpp
+++ b/src/htm/engine/RESTapi.hpp
@@ -39,8 +39,8 @@
  *       that created a Network context and stashed it in a resouces map
  *       indexed by id.
  *
- *       There is a maximum of 65535 active Network class resources.
- *       A Network resource will timeout without activity in 24 hrs.
+ *       There is a maximum of 9999 active Network class resources available
+ *       if you allow REST to assign the id's.  Otherwise the program imposes no limits.
  *
  *       The methods in the class are called from examples/rest/server_core.hpp
  *       which is compiled with the rest server.  An application can use the server
@@ -119,17 +119,19 @@ public:
    * @param id          Identifier for the resource context (a Network class instance).
    *                    Subsequent calls related to this Network object should use this id.
    *                    Note: the id parameter can be an empty string.  If empty the program
-   *                          will use the next available id.  Otherwise it will use and 
-   *                          return the specified id.
+   *                          will generate and use the next available id; a four digit string
+   *                          between "0001" and "9999".  If the id exceeds "9999" it will
+   *                          wrap and re-use id's for which Network objects have been deleted.
    *
-   *                          If a Network object is already associated with the specified id
-   *                          the program will remove the existing Network object and create a new one.
+   *                          Otherwise it will use and return the specified id. The specified id 
+   *                          does not have to be numeric.  However, if it is not compatible with 
+   *                          URL syntax the returned id will be a URLencoded copy of the requested id.
    *
-   *                          The specified id does not have to be numeric.  However, if it is 
-   *                          not compatible with URL syntax the returned id will be a URLencoded
-   *                          copy of the id.
+   *                          If a Network object is already associated with the specified id the 
+   *                          program will remove the existing Network object and create a new one.
    *
-   * @retval            If success returns the id.
+   *
+   * @retval            If successful it returns the id used.
    *                    Otherwise returns error message starting with "ERROR: ".
    */
   std::string put_input_request(const std::string &id, 

--- a/src/htm/utils/Random.hpp
+++ b/src/htm/utils/Random.hpp
@@ -87,7 +87,7 @@ public:
     ar( CEREAL_NVP(seed_), 
 	CEREAL_NVP(steps_)
     );  
-    gen.seed(static_cast<UInt64>(seed_)); //reseed
+    gen.seed(static_cast<unsigned int>(seed_)); //reseed
     gen.discard(steps_); //advance n steps
   }
 

--- a/src/htm/utils/Random.hpp
+++ b/src/htm/utils/Random.hpp
@@ -87,7 +87,7 @@ public:
     ar( CEREAL_NVP(seed_), 
 	CEREAL_NVP(steps_)
     );  
-    gen.seed(static_cast<unsigned int>(seed_)); //reseed
+    gen.seed(static_cast<UInt32>(seed_)); //reseed
     gen.discard(steps_); //advance n steps
   }
 

--- a/src/test/unit/engine/RESTapiTest.cpp
+++ b/src/test/unit/engine/RESTapiTest.cpp
@@ -272,7 +272,8 @@ TEST(RESTapiTest, alternative_ids) {
 
   res = client.Get("/stop"); // stop the server.
 
-  threadObj.join(); // wait until server thread has stopped.
+  // Note:  If the server thread did not stop for some reason
+  //        it will be killed when the main thread finishes.
 }
 
 

--- a/src/test/unit/engine/RESTapiTest.cpp
+++ b/src/test/unit/engine/RESTapiTest.cpp
@@ -39,8 +39,12 @@ namespace testing {
 using namespace htm;
 
 
+static std::string host = "127.0.0.1";
 static int port = 8050;
 static bool verbose = false; // turn this on to print extra stuff for debugging the test.
+
+
+
 #define VERBOSE  if (verbose)  std::cerr << "[          ] "
 #define EPOCHS 3
 
@@ -85,33 +89,70 @@ static std::string log(const Request &req, const Response &res) {
 }
 
 
-static void serverThread() {
-  // This starts the NetworkAPI REST server
-  std::string net_interface = "127.0.0.1";
-  try {
-    RESTserver server;
-    if (verbose) server.set_logger([](const Request &req, const Response &res) { std::cout << log(req, res); });
-    server.listen(port, net_interface.c_str());
-    // will exit listen loop when the "GET /stop" message is received.
-  } catch (Exception &e) {
-    ASSERT_TRUE(false) << "REST Server Error: " << e.getMessage();
-  }
-}
 
-TEST(RESTapiTest, example) {
+
+class RESTapiTest : public ::testing::Test {
+
+protected:
+  std::shared_ptr<httplib::Client> client;
+  std::thread serverThreadObj;
+  RESTserver server;
+  RESTapiTest() {}
+
+  virtual ~RESTapiTest() {}
+
+  void serverThread() { // This function is ran in the server thread.
+    // This starts the NetworkAPI REST server
+    std::string net_interface = "127.0.0.1";
+    try {
+      if (verbose)
+        server.set_logger([](const Request &req, const Response &res) { std::cout << log(req, res); });
+      server.listen(port, net_interface.c_str());
+      // will exit listen loop when the "GET /stop" message is received.
+    } catch (Exception &e) {
+      ASSERT_TRUE(false) << "REST Server Error: " << e.getMessage();
+    }
+  }
+
+
+  virtual void SetUp() {
+    // start the server in a separate thread
+    serverThreadObj = std::thread (&RESTapiTest::serverThread, this); // start REST server
+    std::this_thread::sleep_for(std::chrono::milliseconds(1)); // yield to give server time to start
+    client.reset(new httplib::Client(host, port));
+    client->set_timeout_sec(30);
+  }
+
+  virtual void TearDown() { 
+    // Note:  The server should stop if sent a "/stop" message.
+    //        If the server thread did not stop for some reason
+    //        we need to shut it down by calling server.stop( ).
+    // Normally you don't need to do the check to see if the server is running, etc.
+    // We do this here just to test that the server does shut down.
+
+    client->Get("/stop");                                        // stop the server.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // yield to give server time to stop
+
+    if (server.is_running()) {
+      ASSERT_TRUE(false) << "The server did not shut down with the /stop command within 100ms.";
+      server.stop();  
+    }
+    serverThreadObj.join(); // wait until server thread has stopped.
+
+  }
+};
+
+TEST_F(RESTapiTest, example) {
   // A test similar to the Client Example.
-  std::thread threadObj(serverThread); // start REST server
-  std::this_thread::sleep_for(std::chrono::milliseconds(1)); // yield to give server time to start
 
   // Client thread.
   const httplib::Params noParams;
   char message[1000];
 
-  httplib::Client client("127.0.0.1", port);
-  client.set_timeout_sec(30);
+  client->set_timeout_sec(30);
 
   // request "Hello World" to see if we are able to connect to the server.
-  auto res = client.Get("/hi");
+  auto res = client->Get("/hi");
   ASSERT_TRUE(res) << "No response from server.";
   ASSERT_EQ(res->status,200) << "Unexpected status returned: " << res->status << std::endl;
   EXPECT_STREQ(res->body.c_str(), "Hello World!\n") << "Response to GET /hi request";
@@ -130,13 +171,14 @@ TEST(RESTapiTest, example) {
     ]})";
 
   // create the network object
-  res = client.Post("/network", config, "application/json");
+  res = client->Post("/network", config, "application/json");
   ASSERT_TRUE(res && res->status/100 == 2 && res->body.size() == 5) << "Failed Response to POST /network request.";
   std::string id = res->body.substr(0,4);
+  ASSERT_STREQ(id.c_str(), "0001");
 
   // Send GET parameter message to retreive "tm.cellsPerColumn" parameter from the tm region.
   snprintf(message, sizeof(message), "/network/%s/region/tm/param/cellsPerColumn", id.c_str());
-  res = client.Get(message);
+  res = client->Get(message);
   ASSERT_TRUE(res && res->status/100 == 2) << " GET param message failed.";
   EXPECT_TRUE(trim(res->body) == "8") << "Response to GET param request";
 
@@ -150,37 +192,32 @@ TEST(RESTapiTest, example) {
 
     // Send set parameter message to feed "sensedValue" parameter data into RDSE encoder for this iteration.
     snprintf(message, sizeof(message), "/network/%s/region/encoder/param/sensedValue?data=%.02f", id.c_str() , s);
-    res = client.Put(message, noParams);
+    res = client->Put(message, noParams);
     ASSERT_TRUE(res && res->status / 100 == 2) << " PUT param message failed.";
     EXPECT_STREQ(trim(res->body).c_str(), "OK") << "Response to PUT param request";
 
     // Execute an iteration
     snprintf(message, sizeof(message), "/network/%s/run", id.c_str());
-    res = client.Get(message);
+    res = client->Get(message);
     EXPECT_STREQ(trim(res->body).c_str(), "OK") << "Response to GET run";
   }
 
   // Retreive the final anomaly score from the TM object, 'tm.anomaly'.
   snprintf(message, sizeof(message), "/network/%s/region/tm/output/anomaly", id.c_str());
-  res = client.Get(message);
+  res = client->Get(message);
   ASSERT_TRUE(res && res->status / 100 == 2) << " GET output message failed.";
   EXPECT_STREQ(trim(res->body).c_str(), "{type: \"Real32\",data: [1]}")
       << "Response to GET output request (The Anomaly Score)";
-  res = client.Get("/stop"); // stop the server.
 
-  threadObj.join(); // wait until server thread has stopped.
+
+
 }
 
-TEST(RESTapiTest, test_delete) {
-  std::thread threadObj(serverThread);                  // start REST server
-  std::this_thread::sleep_for(std::chrono::seconds(1)); // give server time to start
+TEST_F(RESTapiTest, test_delete) {
 
   // Client thread.
-  const httplib::Params noParams;
   char message[1000];
 
-  httplib::Client client("127.0.0.1", port);
-  client.set_timeout_sec(30);
 
   // Configure a NetworkAPI example
   // See Network.configure() for syntax.
@@ -196,45 +233,35 @@ TEST(RESTapiTest, test_delete) {
     ]})";
 
   // create the network object
-  auto res = client.Post("/network", config, "application/json");
+  auto res = client->Post("/network", config, "application/json");
   ASSERT_TRUE(res && res->status / 100 == 2 && res->body.size() == 5) << "Failed Response to POST /network request.";
   std::string id = res->body.substr(0, 4);
 
   // Now delete the second link.
   snprintf(message, sizeof(message), "/network/%s/link/sp.bottomUpOut/tm.bottomUpIn", id.c_str());
-  res = client.Delete(message);
+  res = client->Delete(message);
   ASSERT_TRUE(res && res->status / 100 == 2) << " DELETE link message failed.";
   EXPECT_STREQ(trim(res->body).c_str(), "OK") << "Response to DELETE Link request";
 
   // Delete a region
   snprintf(message, sizeof(message), "/network/%s/region/tm", id.c_str());
-  res = client.Delete(message);
+  res = client->Delete(message);
   ASSERT_TRUE(res && res->status / 100 == 2) << " DELETE region message failed.";
   EXPECT_STREQ(trim(res->body).c_str(), "OK") << "Response to DELETE Link request";
   
   // Delete a Network
   snprintf(message, sizeof(message), "/network/%s/ALL", id.c_str());
-  res = client.Delete(message);
+  res = client->Delete(message);
   ASSERT_TRUE(res && res->status / 100 == 2) << " DELETE region message failed.";
   EXPECT_STREQ(trim(res->body).c_str(), "OK") << "Response to DELETE Link request";
   
   
-
-  // wrap up
-  res = client.Get("/stop"); // stop the server.
-  threadObj.join();          // wait until server thread has stopped.
 }
 
 
-TEST(RESTapiTest, alternative_ids) {
-  std::thread threadObj(serverThread); // start REST server
-  std::this_thread::sleep_for(std::chrono::seconds(1)); // give server time to start
+TEST_F(RESTapiTest, alternative_ids) {
 
   // Client thread.
-  const httplib::Params noParams;
-
-  httplib::Client client("127.0.0.1", port);
-  client.set_timeout_sec(30);
 
   // See Network.configure() for syntax.
   //     Simple situation    Just the encoder Encoder, nothing else 
@@ -244,36 +271,28 @@ TEST(RESTapiTest, alternative_ids) {
     ]})";
 
   // create a Network object using a numeric id as a URL parameter
-  auto res = client.Post("/network?id=123", config, "application/json");
+  auto res = client->Post("/network?id=123", config, "application/json");
   ASSERT_TRUE(res && res->status/100 == 2 && res->body.size() > 0) << "Failed Response to POST /network?id=123 request.";
   std::string id = res->body.substr(0, res->body.length() - 1); // remove the \n
   EXPECT_STREQ(id.c_str(), "123");
   
   // create a Network object using a numeric id as a URL field
-  res = client.Post("/network/456", config, "application/json");
+  res = client->Post("/network/456", config, "application/json");
   ASSERT_TRUE(res && res->status/100 == 2 && res->body.size() > 0) << "Failed Response to POST /network/456 request.";
   id = res->body.substr(0, res->body.length() - 1); // remove the \n
   EXPECT_STREQ(id.c_str(), "456");
 
   // create a Network object using a non-numeric id as a URL field
-  res = client.Post("/network/TestObj", config, "application/json");
+  res = client->Post("/network/TestObj", config, "application/json");
   ASSERT_TRUE(res && res->status/100 == 2 && res->body.size() > 0) << "Failed Response to POST /network/TestObj request.";
   id = res->body.substr(0, res->body.length() - 1); // remove the \n
   EXPECT_STREQ(id.c_str(), "TestObj");
 
   // create a Network object using a non-numeric id as a URL parameter that contains URL encoding.
-  res = client.Post("/network?id=%20abc", config, "application/json");
+  res = client->Post("/network?id=%20abc", config, "application/json");
   ASSERT_TRUE(res && res->status/100 == 2 && res->body.size() > 0) << "Failed Response to POST /network?id=%20abc request.";
   id = res->body.substr(0, res->body.length() - 1); // remove the \n
   EXPECT_STREQ(id.c_str(), "%20abc");
-  
-  
-
-
-  res = client.Get("/stop"); // stop the server.
-
-  // Note:  If the server thread did not stop for some reason
-  //        it will be killed when the main thread finishes.
 }
 
 

--- a/src/test/unit/engine/RESTapiTest.cpp
+++ b/src/test/unit/engine/RESTapiTest.cpp
@@ -101,7 +101,7 @@ static void serverThread() {
 TEST(RESTapiTest, example) {
   // A test similar to the Client Example.
   std::thread threadObj(serverThread); // start REST server
-  std::this_thread::sleep_for(std::chrono::seconds(1)); // give server time to start
+  std::this_thread::sleep_for(std::chrono::milliseconds(1)); // yield to give server time to start
 
   // Client thread.
   const httplib::Params noParams;


### PR DESCRIPTION
This allows the following syntax for the POST 
```
POST /network
POST /network/<id>
POST /network?id=<id>
```
It also includes a unit test for the changes.

You may note a few other random changes.  These are to fix "possible loss of data" warnings that showed up after iterators were changed to size_t.  I did not get all of them.  