### PR TITLE
Allows default values in spec to be JSON syntax

### DIFF
--- a/py/htm/examples/rest/htm_rest_api.py
+++ b/py/htm/examples/rest/htm_rest_api.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlencode
 import requests
 import json
+import re
 
 
 class NetworkRESTError(Exception):
@@ -22,17 +23,11 @@ def request(method, url, data=None, verbose=False):
   if text[0:6] == 'ERROR:':
     raise NetworkRESTError(text[6:].strip())
 
-  if text == 'OK':
+  # determine if result contains JSON i.e. it starts with '{' for a map or '[' for an array
+  if text[0:1] == '[' or text[0:1] == '{':
+    return json.loads( text )
+  else:
     return text
-
-  idx = text.find('[')
-
-  if idx == -1:
-    return text
-
-  data = text[idx + 1:].replace(']}', '')
-
-  return json.loads('[' + data + ']')
 
 
 class NetworkRESTBase(object):

--- a/py/tests/rest/htm_rest_api_test.py
+++ b/py/tests/rest/htm_rest_api_test.py
@@ -26,7 +26,7 @@ EPOCHS = 3
 class HtmRestApiTest(unittest.TestCase):
   def setUp(self):
     self._process = subprocess.Popen([REST_SERVER, '8050', '127.0.0.1'])
-    sleep(0.1)
+    sleep(0.2)
 
   def testNetworkRESTBaseExample(self):
     rsp = requests.get(HOST + '/hi')
@@ -193,8 +193,9 @@ class HtmRestApiTest(unittest.TestCase):
       r = requests.get('{}/stop'.format(HOST))
     except:
       pass
-    sleep(0.1)
+    sleep(0.01)
     self._process.terminate()
+    sleep(0.1)
 
     self._process.wait(1)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ project(htm_core CXX)
 
 message(STATUS "Configuring htm_core src")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set(CMAKE_VERBOSE_MAKEFILE ON) # toggle for cmake debug
+set(CMAKE_VERBOSE_MAKEFILE OFF) # toggle for cmake debug
 include(src/NupicLibraryUtils) # for combining static libs
 include(src/ExpandStaticLib)   # for creating objects from a static lib
 

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -356,7 +356,7 @@ void SpatialPooler::setPermanence(UInt column, const Real permanences[]) {
 
 void SpatialPooler::getConnectedCounts(UInt connectedCounts[]) const {
   for(size_t seg = 0; seg < numColumns_; seg++) { //in SP each column = 1 cell with 1 segment only.
-    const auto &segment = connections_.dataForSegment( seg );
+    const auto &segment = connections_.dataForSegment( (htm::Segment)seg );
     connectedCounts[ seg ] = segment.numConnected; //TODO numConnected only used here, rm from SegmentData and compute for each segment.synapses?
   }
 }
@@ -451,7 +451,7 @@ void SpatialPooler::initialize(
     vector<Real> perm = initPermanence_(potential, initConnectedPct_);
     for(size_t presyn = 0; presyn < numInputs_; presyn++) {
       if( potential[presyn] )
-        connections_.createSynapse( static_cast<Segment>(i), presyn, perm[presyn] );
+        connections_.createSynapse( static_cast<Segment>(i), static_cast<htm::CellIdx>(presyn), perm[presyn] );
     }
 
     connections_.raisePermanencesToThreshold( (Segment)i, stimulusThreshold_ );
@@ -621,7 +621,7 @@ void SpatialPooler::updateMinDutyCyclesGlobal_() {
 
 
 void SpatialPooler::updateMinDutyCyclesLocal_() {
-  for (size_t i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++) {
     Real maxActiveDuty = 0.0f;
     Real maxOverlapDuty = 0.0f;
     if (wrapAround_) {
@@ -630,7 +630,7 @@ void SpatialPooler::updateMinDutyCyclesLocal_() {
       maxOverlapDuty = max(maxOverlapDuty, overlapDutyCycles_[column]);
      }
     } else {
-     for(auto column: Neighborhood(i, inhibitionRadius_, columnDimensions_)) {
+      for (auto column : Neighborhood(i, inhibitionRadius_, columnDimensions_)) {
       maxActiveDuty = max(maxActiveDuty, activeDutyCycles_[column]);
       maxOverlapDuty = max(maxOverlapDuty, overlapDutyCycles_[column]);
       }
@@ -648,7 +648,7 @@ void SpatialPooler::updateDutyCycles_(const vector<SynapseIdx> &overlaps,
   // avoid copies and  type convertions.
   SDR newOverlap({ numColumns_ });
   auto &overlapsSparseVec = newOverlap.getSparse();
-  for (size_t i = 0; i < numColumns_; i++) {
+  for (UInt i = 0; i < numColumns_; i++) {
     if( overlaps[i] != 0 )
       overlapsSparseVec.push_back( i );
   }
@@ -788,7 +788,7 @@ void SpatialPooler::updateBoostFactorsGlobal_() {
 
 
 void SpatialPooler::updateBoostFactorsLocal_() {
-  for (size_t i = 0; i < numColumns_; ++i) {
+  for (UInt i = 0; i < numColumns_; ++i) {
     UInt numNeighbors = 0u;
     Real localActivityDensity = 0.0f;
 
@@ -888,7 +888,7 @@ void SpatialPooler::inhibitColumnsLocal_(const vector<Real> &overlaps,
   // selected are treated as "bigger".
   vector<bool> activeColumnsDense(numColumns_, false);
 
-  for (size_t column = 0; column < numColumns_; column++) {
+  for (UInt column = 0; column < numColumns_; column++) {
     if (overlaps[column] < stimulusThreshold_) {
       continue;
     }

--- a/src/htm/algorithms/TemporalMemory.cpp
+++ b/src/htm/algorithms/TemporalMemory.cpp
@@ -414,7 +414,7 @@ void TemporalMemory::activateDendrites(const bool learn,
   activeSegments_.clear();
   for (size_t segment = 0; segment < numActiveConnectedSynapsesForSegment_.size(); segment++) {
     if (numActiveConnectedSynapsesForSegment_[segment] >= activationThreshold_) { //TODO move to SegmentData.numConnected?
-      activeSegments_.push_back(segment);
+      activeSegments_.push_back(static_cast<UInt>(segment));
     }
   }
   const auto compareSegments = [&](const Segment a, const Segment b) { return connections.compareSegments(a, b); };
@@ -430,7 +430,7 @@ void TemporalMemory::activateDendrites(const bool learn,
   matchingSegments_.clear();
   for (size_t segment = 0; segment < numActivePotentialSynapsesForSegment_.size(); segment++) {
     if (numActivePotentialSynapsesForSegment_[segment] >= minThreshold_) {
-      matchingSegments_.push_back(segment);
+      matchingSegments_.push_back(static_cast<UInt>(segment));
     }
   }
   std::sort( matchingSegments_.begin(), matchingSegments_.end(), compareSegments);

--- a/src/htm/engine/Input.cpp
+++ b/src/htm/engine/Input.cpp
@@ -172,7 +172,7 @@ void Input::initialize() {
     // ask the spec for destination region.
     UInt32 count = destSpec->inputs.getByName(name_).count;
     if (count > 0) {
-      inD.push_back(count);
+      inD.push_back(count); // fixed count in spec
     } else {
       // ask the destination region impl
       inD = region_->askImplForInputDimensions(name_);

--- a/src/htm/engine/RegionImpl.cpp
+++ b/src/htm/engine/RegionImpl.cpp
@@ -18,11 +18,11 @@
 #include <iostream>
 
 #include <htm/engine/Region.hpp>
+#include <htm/engine/RegionImpl.hpp>
 #include <htm/engine/Spec.hpp>
 #include <htm/ntypes/Array.hpp>
-#include <htm/ntypes/Dimensions.hpp>
 #include <htm/ntypes/BasicType.hpp>
-#include <htm/engine/RegionImpl.hpp>
+#include <htm/ntypes/Dimensions.hpp>
 
 namespace htm {
 
@@ -35,7 +35,6 @@ std::string RegionImpl::getType() const { return region_->getType(); }
 
 std::string RegionImpl::getName() const { return region_->getName(); }
 
-
 /* ------------- Parameter support --------------- */
 // By default, all typed getParameter calls forward to the
 // untyped getParameter that serializes to a buffer
@@ -45,21 +44,17 @@ std::string RegionImpl::getName() const { return region_->getName(); }
 // templated methods can't be virtual and thus can't be
 // overridden by subclasses.
 
-#define getParameterInternalT(MethodT, Type)                                   \
-  Type RegionImpl::getParameter##MethodT(const std::string &name,              \
-                                         Int64 index) {                        \
-    if (!region_->getSpec()->parameters.contains(name))                        \
-      NTA_THROW << "getParameter" #Type ": Region type " << getType()          \
-	            << ", parameter " << name                                      \
-                << " does not exist in region spec";                              \
-    ParameterSpec p = region_->getSpec()->parameters.getByName(name);          \
-    if (p.dataType != NTA_BasicType_##MethodT)                                 \
-      NTA_THROW << "getParameter" #Type ": Region type " << getType()          \
-	            << ", parameter " << name                                      \
-                << " is of type " << BasicType::getName(p.dataType)            \
-                << " not " #Type;                                              \
-    NTA_THROW << "getParameter" #Type " --  parameter '"       \
-                << name << "' on region of type " << getType() << " not implemented"; \
+#define getParameterInternalT(MethodT, Type)                                                                           \
+  Type RegionImpl::getParameter##MethodT(const std::string &name, Int64 index) {                                       \
+    if (!region_->getSpec()->parameters.contains(name))                                                                \
+      NTA_THROW << "getParameter" #Type ": Region type " << getType() << ", parameter " << name                        \
+                << " does not exist in region spec";                                                                   \
+    ParameterSpec p = region_->getSpec()->parameters.getByName(name);                                                  \
+    if (p.dataType != NTA_BasicType_##MethodT)                                                                         \
+      NTA_THROW << "getParameter" #Type ": Region type " << getType() << ", parameter " << name << " is of type "      \
+                << BasicType::getName(p.dataType) << " not " #Type;                                                    \
+    NTA_THROW << "getParameter" #Type " --  parameter '" << name << "' on region of type " << getType()                \
+              << " not implemented";                                                                                   \
   }
 
 #define getParameterT(Type) getParameterInternalT(Type, Type)
@@ -71,23 +66,19 @@ getParameterT(UInt64) getParameterT(Real32);
 getParameterT(Real64);
 getParameterInternalT(Bool, bool);
 
-#define setParameterInternalT(MethodT, Type)                                   \
-  void RegionImpl::setParameter##MethodT(const std::string &name, Int64 index, \
-                                         Type value) {                         \
-    if (!region_->getSpec()->parameters.contains(name))                        \
-      NTA_THROW << "setParameter" #Type ": Region type " << getType()          \
-	            << ", parameter " << name                                      \
-                << " does not exist in Spec";                                  \
-    ParameterSpec p = region_->getSpec()->parameters.getByName(name);          \
-    if (p.dataType != NTA_BasicType_##MethodT)                                 \
-      NTA_THROW << "setParameter" #Type ": Region type " << getType()          \
-	            << ", parameter " << name                                      \
-                << " is of type " << BasicType::getName(p.dataType)            \
-                << " not " #Type;                                              \
-    if (p.accessMode != ParameterSpec::ReadWriteAccess)                        \
-      NTA_THROW << "setParameter" #Type " --  parameter '" << name << " is Readonly"; \
-    NTA_THROW << "setParameter" #Type " -- Region type " << getType()          \
-			    << ", parameter '" << name << "' not implemented";             \
+#define setParameterInternalT(MethodT, Type)                                                                           \
+  void RegionImpl::setParameter##MethodT(const std::string &name, Int64 index, Type value) {                           \
+    if (!region_->getSpec()->parameters.contains(name))                                                                \
+      NTA_THROW << "setParameter" #Type ": Region type " << getType() << ", parameter " << name                        \
+                << " does not exist in Spec";                                                                          \
+    ParameterSpec p = region_->getSpec()->parameters.getByName(name);                                                  \
+    if (p.dataType != NTA_BasicType_##MethodT)                                                                         \
+      NTA_THROW << "setParameter" #Type ": Region type " << getType() << ", parameter " << name << " is of type "      \
+                << BasicType::getName(p.dataType) << " not " #Type;                                                    \
+    if (p.accessMode != ParameterSpec::ReadWriteAccess)                                                                \
+      NTA_THROW << "setParameter" #Type " --  parameter '" << name << " is Readonly";                                  \
+    NTA_THROW << "setParameter" #Type " -- Region type " << getType() << ", parameter '" << name                       \
+              << "' not implemented";                                                                                  \
   }
 
 #define setParameterT(Type) setParameterInternalT(Type, Type)
@@ -102,73 +93,58 @@ setParameterInternalT(Bool, bool);
 
 void RegionImpl::getParameterArray(const std::string &name, Int64 index, Array &array) {
   if (!region_->getSpec()->parameters.contains(name))
-      NTA_THROW << "setParameterArray: parameter " << name
-                << " does not exist in Spec";
+    NTA_THROW << "setParameterArray: parameter " << name << " does not exist in Spec";
   ParameterSpec p = region_->getSpec()->parameters.getByName(name);
 
-  NTA_THROW << "getParameterArray: parameter '" << name
-            << "' an array with a type of "
-			<< BasicType::getName(p.dataType)
-			<< " is found in the region spec but is not implemented.";
+  NTA_THROW << "getParameterArray: parameter '" << name << "' an array with a type of "
+            << BasicType::getName(p.dataType) << " is found in the region spec but is not implemented.";
 }
 
 void RegionImpl::setParameterArray(const std::string &name, Int64 index, const Array &array) {
   if (!region_->getSpec()->parameters.contains(name))
-      NTA_THROW << "setParameterArray: parameter " << name
-                << " does not exist in Spec for this region.";
+    NTA_THROW << "setParameterArray: parameter " << name << " does not exist in Spec for this region.";
   ParameterSpec p = region_->getSpec()->parameters.getByName(name);
   if (p.dataType != array.getType()) {
-      NTA_THROW << "setParameterArray: parameter " << name
-                << " is of type " << BasicType::getName(p.dataType)
-                << " not " << BasicType::getName(array.getType());
+    NTA_THROW << "setParameterArray: parameter " << name << " is of type " << BasicType::getName(p.dataType) << " not "
+              << BasicType::getName(array.getType());
   }
-  NTA_THROW	<< "setParameterArray: parameter '" << name
-            << " is found in the spec for " << getType() <<" but is not implemented.";
+  NTA_THROW << "setParameterArray: parameter '" << name << " is found in the spec for " << getType()
+            << " but is not implemented.";
 }
 
-void RegionImpl::setParameterString(const std::string &name, Int64 index,
-                                    const std::string &s) {
+void RegionImpl::setParameterString(const std::string &name, Int64 index, const std::string &s) {
   if (!region_->getSpec()->parameters.contains(name))
-      NTA_THROW << "setParameterString: parameter " << name
-                << " does not exist in Spec";
+    NTA_THROW << "setParameterString: parameter " << name << " does not exist in Spec";
   ParameterSpec p = region_->getSpec()->parameters.getByName(name);
   if (p.dataType != NTA_BasicType_Byte) {
-      NTA_THROW << "setParameterString: parameter " << name
-                << " is of type " << BasicType::getName(p.dataType)
-                << " not Byte (string)";
+    NTA_THROW << "setParameterString: parameter " << name << " is of type " << BasicType::getName(p.dataType)
+              << " not Byte (string)";
   }
-  NTA_THROW << "setParameterString: parameter '" << name
-			<< " is found in the spec for " << getType() <<" but is not implemented.";
+  NTA_THROW << "setParameterString: parameter '" << name << " is found in the spec for " << getType()
+            << " but is not implemented.";
 }
 
-std::string RegionImpl::getParameterString(const std::string &name,
-                                           Int64 index) {
+std::string RegionImpl::getParameterString(const std::string &name, Int64 index) {
   if (!region_->getSpec()->parameters.contains(name))
-      NTA_THROW << "getParameterString: parameter " << name
-                << " does not exist in Spec";
+    NTA_THROW << "getParameterString: parameter " << name << " does not exist in Spec";
   ParameterSpec p = region_->getSpec()->parameters.getByName(name);
   if (p.dataType != NTA_BasicType_Byte) {
-      NTA_THROW << "getParameterString: parameter " << name
-                << " is of type " << BasicType::getName(p.dataType)
-                << " not Byte (string)";
+    NTA_THROW << "getParameterString: parameter " << name << " is of type " << BasicType::getName(p.dataType)
+              << " not Byte (string)";
   }
-  NTA_THROW << "getParameterString: parameter '" << name
-			<< " is found in the spec for " << getType() <<" but is not implemented.";
+  NTA_THROW << "getParameterString: parameter '" << name << " is found in the spec for " << getType()
+            << " but is not implemented.";
   return "";
 }
 
-
-
-size_t RegionImpl::getParameterArrayCount(const std::string &name,
-                                          Int64 index) {
+size_t RegionImpl::getParameterArrayCount(const std::string &name, Int64 index) {
   // Default implementation for RegionImpls with no array parameters
   // that have a dynamic length.
   // std::map<std::string, ParameterSpec*>::iterator i =
   // nodespec_->parameters.find(name); if (i == nodespec_->parameters.end())
 
   if (!region_->getSpec()->parameters.contains(name)) {
-    NTA_THROW << "getParameterArrayCount -- no parameter named '" << name
-              << "' in node of type " << getType();
+    NTA_THROW << "getParameterArrayCount -- no parameter named '" << name << "' in node of type " << getType();
   }
   UInt32 count = (UInt32)region_->getSpec()->parameters.getByName(name).count;
   if (count == 0) {
@@ -188,14 +164,13 @@ Dimensions RegionImpl::askImplForInputDimensions(const std::string &name) {
   // Since the region impl did not override this, we generate the Dimensions
   // based on the Spec.
   if (!region_->getSpec()->inputs.contains(name)) {
-    NTA_THROW << "askImplForInputDimensions -- no input named '" << name
-              << "' in region of type " << getType();
+    NTA_THROW << "askImplForInputDimensions -- no input named '" << name << "' in region of type " << getType();
   }
   UInt32 count = (UInt32)region_->getSpec()->inputs.getByName(name).count;
   if (count == Spec::VARIABLE)
     count = (UInt32)getNodeInputElementCount(name);
   Dimensions dim;
-  dim.push_back(count);   // if count == 0, it means don't care.
+  dim.push_back(count); // if count == 0, it means don't care.
   return dim;
 }
 
@@ -207,8 +182,7 @@ Dimensions RegionImpl::askImplForOutputDimensions(const std::string &name) {
   // Since the region impl did not override this, we generate the Dimensions
   // based on the Spec.
   if (!region_->getSpec()->outputs.contains(name)) {
-    NTA_THROW << "askImplForOutputDimensions -- no output named '" << name
-              << "' in region of type " << getType();
+    NTA_THROW << "askImplForOutputDimensions -- no output named '" << name << "' in region of type " << getType();
   }
   auto ns = region_->getSpec()->outputs.getByName(name);
 
@@ -222,37 +196,30 @@ Dimensions RegionImpl::askImplForOutputDimensions(const std::string &name) {
     // provided that count is 0 or that count is same element size as regionLevel.
     if (ns.regionLevel && dim_.isSpecified()) {
       if (count == 0 || count == dim_.getCount())
-      return dim_;
+        return dim_;
     }
   }
   Dimensions dim;
-  dim.push_back(count);   // if count happens to be 0, it means don't care.
+  dim.push_back(count); // if count happens to be 0, it means don't care.
   return dim;
 }
 
-
-std::string RegionImpl::executeCommand(const std::vector<std::string> &args,Int64 index) {
+std::string RegionImpl::executeCommand(const std::vector<std::string> &args, Int64 index) {
   // This Region does not execute any Commands.
   return "";
 }
 
 // Provide data access for subclasses
 
-std::shared_ptr<Input> RegionImpl::getInput(const std::string &name) const {
-  return region_->getInput(name);
-}
+std::shared_ptr<Input> RegionImpl::getInput(const std::string &name) const { return region_->getInput(name); }
 
 std::shared_ptr<Output> RegionImpl::getOutput(const std::string &name) const {
   auto out = region_->getOutput(name);
   NTA_CHECK(out != nullptr) << "Requested output not found: " << name;
   return out;
 }
-Dimensions RegionImpl::getInputDimensions(const std::string &name) const {
-  return region_->getInputDimensions(name);
-}
-Dimensions RegionImpl::getOutputDimensions(const std::string &name) const {
-  return region_->getOutputDimensions(name);
-}
+Dimensions RegionImpl::getInputDimensions(const std::string &name) const { return region_->getInputDimensions(name); }
+Dimensions RegionImpl::getOutputDimensions(const std::string &name) const { return region_->getOutputDimensions(name); }
 
 /**
  * Checks the parameters in the ValueMap and gives an error if it
@@ -261,12 +228,12 @@ Dimensions RegionImpl::getOutputDimensions(const std::string &name) const {
  * Returns a modifiable deep copy of the ValueMap with defaults inserted.
  * For optional use by C++ implemented Regions.
  */
-ValueMap RegionImpl::ValidateParameters(const ValueMap &vm, Spec* ns) {
-  
+ValueMap RegionImpl::ValidateParameters(const ValueMap &vm, Spec *ns) {
+
   ValueMap new_vm = vm.copy();
 
   // Look for parameters that don't belong
-  for (auto p: new_vm) {
+  for (auto p : new_vm) {
     std::string key = p.first;
     Value v = p.second;
     if (key == "dim")
@@ -274,25 +241,50 @@ ValueMap RegionImpl::ValidateParameters(const ValueMap &vm, Spec* ns) {
     if (!ns->parameters.contains(key))
       NTA_THROW << "Parameter '" << key << "' is not expected for region '" << getName() << "'.";
   }
-  
 
   // Look for missing parameters and apply their default value.
   for (auto p : ns->parameters) {
     std::string key = p.first;
     ParameterSpec &ps = p.second;
     if (!ps.defaultValue.empty()) {
-      if (!new_vm.contains(key) || new_vm.getString(key, "").length() == 0) {
-        // a missing or empty parameter.
-        new_vm[key].parse(ps.defaultValue);
-        std::string x = new_vm.to_json();
+      if (new_vm.contains(key) && new_vm.getString(key, "").length() > 0) {
+        // It has a provided value.
+        NTA_CHECK(ps.accessMode != ParameterSpec::ReadOnlyAccess)
+            << getName() << " Parameter '" << key
+            << "', Cannot use a READ_ONLY parameter for Region creation.";
+      } else {
+        // This is a missing or empty parameter 
+        // Note, we are going to allow a default value to be applied to a Readonly field.
+        if (ps.dataType == NTA_BasicType_Str && ps.count == 1) {
+          new_vm[key] = ps.defaultValue;  // A scaler string.
+        } else {
+          try {
+            new_vm[key].parse(ps.defaultValue);
+          } catch (Exception &ex) {
+            NTA_THROW << getName() << " Parameter '" << key << "', Error parsing default value: " << ex.what();
+          }
+          if (ps.count == 1) {
+            NTA_CHECK(new_vm[key].isScalar())
+                << getName() << " Parameter '" << key
+                << "', The default is inconsistant with the spec. 'count' = 1 means expect a scalar."
+                << "Found: " << ps.defaultValue;
+          } else if (ps.count == 0) {
+            NTA_CHECK(!new_vm[key].isScalar())
+                << getName() << " Parameter '" << key
+                << "', The default inconsistant with the spec. 'count' = 0 means expect an array or map."
+                << "Found: " << ps.defaultValue;
+          } else {
+            NTA_CHECK(new_vm[key].isSequence() && new_vm[key].size() == ps.count)
+                << getName() << " Parameter '" << key
+                << "', The default inconsistant with the spec. 'count' > 1 means expect a fixed length array. "
+                << "Found: " << ps.defaultValue;
+          }
+        }
       }
     }
   }
-  
+
   return new_vm;
-
 }
-
-
 
 } // namespace htm

--- a/src/htm/engine/RegionImpl.cpp
+++ b/src/htm/engine/RegionImpl.cpp
@@ -281,9 +281,10 @@ ValueMap RegionImpl::ValidateParameters(const ValueMap &vm, Spec* ns) {
     std::string key = p.first;
     ParameterSpec &ps = p.second;
     if (!ps.defaultValue.empty()) {
-      if (new_vm.getString(key, "").length() == 0) {
+      if (!new_vm.contains(key) || new_vm.getString(key, "").length() == 0) {
         // a missing or empty parameter.
-        new_vm[key] = ps.defaultValue;
+        new_vm[key].parse(ps.defaultValue);
+        std::string x = new_vm.to_json();
       }
     }
   }

--- a/src/htm/engine/Watcher.cpp
+++ b/src/htm/engine/Watcher.cpp
@@ -215,6 +215,22 @@ void Watcher::watcherCallback(Network *net, UInt64 iteration, void *dataIn) {
           }
           break;
         }
+        case NTA_BasicType_Str: {
+          Array a(NTA_BasicType_Str);
+          watch.region->getParameterArray(watch.varName, a);
+          std::string *buf = (std::string *)a.getBuffer();
+          out << a.getCount();
+          if (watch.sparseOutput) {
+            for (UInt j = 0; j < a.getCount(); j++) {
+              out << " " << buf[j];
+            }
+          } else {
+            for (UInt j = 0; j < a.getCount(); j++) {
+              out << " " << buf[j];
+            }
+          }
+          break;
+        }
         default:
           NTA_THROW << "Internal error.";
         } // switch
@@ -251,6 +267,11 @@ void Watcher::watcherCallback(Network *net, UInt64 iteration, void *dataIn) {
           break;
         }
         case NTA_BasicType_Byte: {
+          std::string p = watch.region->getParameterString(watch.varName);
+          out << p;
+          break;
+        }
+        case NTA_BasicType_Str: {
           std::string p = watch.region->getParameterString(watch.varName);
           out << p;
           break;
@@ -406,10 +427,12 @@ void Watcher::attachToNetwork(Network& net)
           watch.varType != NTA_BasicType_UInt32 &&
           watch.varType != NTA_BasicType_Int64 &&
           watch.varType != NTA_BasicType_UInt64 &&
-          watch.varType != NTA_BasicType_Real32 &&
+          watch.varType != NTA_BasicType_Real32 && 
           watch.varType != NTA_BasicType_Real64 &&
+          watch.varType != NTA_BasicType_SDR && 
+          watch.varType != NTA_BasicType_Str &&
           watch.varType != NTA_BasicType_Byte) {
-        NTA_THROW << BasicType::getName(watch.varType) << " is not an "
+            NTA_THROW << BasicType::getName(watch.varType) << " is not an "
                   << "array parameter type supported by Watcher.";
       }
 

--- a/src/htm/ntypes/Array.hpp
+++ b/src/htm/ntypes/Array.hpp
@@ -202,13 +202,10 @@ public:
       : ArrayBase(BasicType::getType<T>()) {
     allocateBuffer(vect.size());
     if (has_buffer()) {
-      if (type_ == NTA_BasicType_Str) { // cannot use memcpy on strings so iterate.
-        T *ptr = (T *)getBuffer();
-        for (size_t i = 0; i < count_; i++) {
-          ptr[i] = vect[i];
-        }
-      } else {
-        memcpy(getBuffer(), vect.data(), count_ * BasicType::getSize(type_));
+      // iterate the elements in the vector so we don't need to worry about the size of it's internal elements.
+      T *ptr = (T *)getBuffer();
+      for (size_t i = 0; i < count_; i++) {
+        ptr[i] = vect[i];
       }
     }
 

--- a/src/htm/regions/TestNode.cpp
+++ b/src/htm/regions/TestNode.cpp
@@ -35,17 +35,23 @@
 
 namespace htm {
 
-TestNode::TestNode(const ValueMap &params, Region *region)
+TestNode::TestNode(const ValueMap &par, Region *region)
     : RegionImpl(region), computeCallback_(nullptr), nodeCount_(1)
 {
+  spec_.reset(createSpec());
+  ValueMap params = ValidateParameters(par, spec_.get());
+
   // params for get/setParameter testing
-    // Populate the parameters with values.
-  outputElementCount_ = params.getScalarT<UInt32>("count", 0);
-  int32Param_ = params.getScalarT<Int32>("int32Param", 32);
-  uint32Param_ = params.getScalarT<UInt32>("uint32Param", 33);
-  int64Param_ = params.getScalarT<Int64>("int64Param", 64);
-  uint64Param_ = params.getScalarT<UInt64>("uint64Param", 65);
-  real32Param_ = params.getScalarT<Real32>("real32Param", 32.1f);
+  // Populate the parameters with values from the ValueMap with defaults from spec applied.
+  int32Param_ = params["int32Param"].as<Int32>();
+  uint32Param_ = params["uint32Param"].as<UInt32>();
+  int64Param_ = params["int64Param"].as<Int64>();
+
+  // An alternate syntax
+  uint64Param_ = params.getScalarT<UInt64>("uint64Param");
+  real32Param_ = params.getScalarT<Real32>("real32Param");
+
+  // overriding the defaults in the spec.
   real64Param_ = params.getScalarT<Real64>("real64Param", 64.1);
   boolParam_ = params.getScalarT<bool>("boolParam", false);
 
@@ -63,10 +69,7 @@ TestNode::TestNode(const ValueMap &params, Region *region)
     int64ArrayParam_[i] = i * 64;
   }
 
-  boolArrayParam_.resize(4);
-  for (size_t i = 0; i < 4; i++) {
-    boolArrayParam_[i] = (i % 2) == 1;
-  }
+  boolArrayParam_ = params["boolArrayParam"].asVector<bool>();
 
   unclonedParam_.resize(nodeCount_);
   unclonedParam_[0] = params.getScalarT<UInt32>("unclonedParam", 0);
@@ -219,12 +222,12 @@ Spec *TestNode::createSpec() {
   ns->parameters.add( "count",
                      ParameterSpec(
 							                   "Buffer size for bottomUpOut Output. "
-                                 "Syntax: {count: 64}",  // description
+                                 "To set it, use dim parameter, i.e. {dim: [64]}",  // description
 	                               NTA_BasicType_UInt32,
 							                   1,                         // elementCount 
 							                   "",                        // constraints
 							                   "",                        // defaultValue
-							                   ParameterSpec::ReadWriteAccess));
+							                   ParameterSpec::ReadOnlyAccess));
 
 
   ns->parameters.add("int32Param",
@@ -298,20 +301,20 @@ Spec *TestNode::createSpec() {
 								   ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("boolArrayParam",
-                     ParameterSpec("bool array parameter", // description
-					               NTA_BasicType_Bool,
-                                   0, // array
-                                   "", // constraints
-								   "", // default Value
+                   ParameterSpec("bool array parameter", // description
+					         NTA_BasicType_Bool,
+                   0, // array
+                   "", // constraints
+								   "[false, true, false, true]", // default Value, array in JSON syntax
 								   ParameterSpec::ReadOnlyAccess));
 
   ns->parameters.add("computeCallback",
                      ParameterSpec("address of a function that is called at every compute()",
-                                   NTA_BasicType_UInt64,
-					               1,  // element count
-					               "", // constraints
-                                   "", // handles must not have a default value
-                                   ParameterSpec::ReadWriteAccess));
+                     NTA_BasicType_UInt64,
+					           1,  // element count
+					           "", // constraints
+                     "", // handles must not have a default value
+                     ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("stringParam",
                      ParameterSpec("string parameter",
@@ -478,6 +481,9 @@ void TestNode::getParameterArray(const std::string &name, Int64 index, Array &ar
     }
 	  Array a(NTA_BasicType_Int64, &unclonedInt64ArrayParam_[static_cast<size_t>(index)][0], 
                                   unclonedInt64ArrayParam_[static_cast<size_t>(index)].size());
+    array = a;
+  } else if (name == "boolArrayParam") {
+    Array a(boolArrayParam_);
     array = a;
   } else {
     NTA_THROW << "TestNode::getParameterArray -- unknown parameter " << name;

--- a/src/htm/regions/TestNode.cpp
+++ b/src/htm/regions/TestNode.cpp
@@ -38,6 +38,7 @@ namespace htm {
 TestNode::TestNode(const ValueMap &par, Region *region)
     : RegionImpl(region), computeCallback_(nullptr), nodeCount_(1)
 {
+  outputElementCount_ = 0;
   spec_.reset(createSpec());
   ValueMap params = ValidateParameters(par, spec_.get());
 
@@ -220,23 +221,22 @@ Spec *TestNode::createSpec() {
 
   /* ---- parameters ------ */
   ns->parameters.add( "count",
-                     ParameterSpec(
-							                   "Buffer size for bottomUpOut Output. "
-                                 "To set it, use dim parameter, i.e. {dim: [64]}",  // description
-	                               NTA_BasicType_UInt32,
-							                   1,                         // elementCount 
-							                   "",                        // constraints
-							                   "",                        // defaultValue
-							                   ParameterSpec::ReadOnlyAccess));
+                     ParameterSpec( "Buffer size for bottomUpOut Output. "
+                                    "To set it, use 'dim' parameter, i.e. {dim: [64]}",  // description
+	                                  NTA_BasicType_UInt32,
+							                      1,                         // elementCount 
+							                      "",                        // constraints
+							                      "",                        // defaultValue
+							                      ParameterSpec::ReadOnlyAccess));
 
 
   ns->parameters.add("int32Param",
                      ParameterSpec("Int32 scalar parameter", // description
-                                   NTA_BasicType_Int32,
-                                   1,    // elementCount
-                                   "",   // constraints
-                                   "32", // defaultValue
-                                   ParameterSpec::ReadWriteAccess));
+                                    NTA_BasicType_Int32,
+                                    1,    // elementCount
+                                    "",   // constraints
+                                    "32", // defaultValue
+                                    ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("uint32Param",
                      ParameterSpec("UInt32 scalar parameter", // description
@@ -293,36 +293,36 @@ Spec *TestNode::createSpec() {
                                    "", "", ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("int64ArrayParam",
-                     ParameterSpec("int64 array parameter",  // description
-					               NTA_BasicType_Int64,
-                                   0, // array
-                                   "", // constraints
-								   "", // default Value
-								   ParameterSpec::ReadWriteAccess));
+                     ParameterSpec( "int64 array parameter",  // description
+                                    NTA_BasicType_Int64,
+                                    0, // array
+                                    "", // constraints
+                                    "", // default Value
+                                    ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("boolArrayParam",
-                   ParameterSpec("bool array parameter", // description
-					         NTA_BasicType_Bool,
-                   0, // array
-                   "", // constraints
-								   "[false, true, false, true]", // default Value, array in JSON syntax
-								   ParameterSpec::ReadOnlyAccess));
+                   ParameterSpec( "bool array parameter", // description
+					                         NTA_BasicType_Bool,
+                                   0, // array
+                                   "", // constraints
+								                   "[false, true, false, true]", // default Value, array in JSON syntax
+								                   ParameterSpec::ReadOnlyAccess));
 
   ns->parameters.add("computeCallback",
                      ParameterSpec("address of a function that is called at every compute()",
-                     NTA_BasicType_UInt64,
-					           1,  // element count
-					           "", // constraints
-                     "", // handles must not have a default value
-                     ParameterSpec::ReadWriteAccess));
+                                   NTA_BasicType_UInt64,
+					                         1,  // element count
+					                         "", // constraints
+                                   "", // handles must not have a default value
+                                   ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("stringParam",
                      ParameterSpec("string parameter",
-					               NTA_BasicType_Byte,
-                                   0, // length=0 required for strings
-                                   "",
-								   "nodespec value",
-                                   ParameterSpec::ReadWriteAccess));
+                                    NTA_BasicType_Str,
+                                    1, // a scalar string
+                                    "",
+                                    "nodespec value",
+                                    ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("unclonedParam",
                      ParameterSpec("has a separate value for each node", // description
@@ -333,28 +333,28 @@ Spec *TestNode::createSpec() {
                                    ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("shouldCloneParam",
-				      ParameterSpec("whether possiblyUnclonedParam should clone", // description
-				                    NTA_BasicType_UInt32,
-				                    1,            // elementCount
-				                    "enum: 0, 1", // constraints
-				                    "1",          // defaultValue
-				                    ParameterSpec::ReadWriteAccess));
+				            ParameterSpec("whether possiblyUnclonedParam should clone", // description
+				                          NTA_BasicType_UInt32,
+				                          1,            // elementCount
+				                          "enum: 0, 1", // constraints
+				                          "1",          // defaultValue
+				                          ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("possiblyUnclonedParam",
-				      ParameterSpec("cloned if shouldCloneParam is true", // description
-				                    NTA_BasicType_UInt32,
-				                    1,  // elementCount
-				                    "", // constraints
-				                    "", // defaultValue
-				                    ParameterSpec::ReadWriteAccess));
+				            ParameterSpec("cloned if shouldCloneParam is true", // description
+				                          NTA_BasicType_UInt32,
+				                          1,  // elementCount
+				                          "", // constraints
+				                          "", // defaultValue
+				                          ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("unclonedInt64ArrayParam",
-				      ParameterSpec("has a separate array for each node", // description
-				                    NTA_BasicType_Int64,
-				                    0,  // array                            //elementCount
-				                    "", // constraints
-				                    "", // defaultValue
-				                    ParameterSpec::ReadWriteAccess));
+				            ParameterSpec("has a separate array for each node", // description
+				                          NTA_BasicType_Int64,
+				                          0,  // array                            //elementCount
+				                          "", // constraints
+				                          "", // defaultValue
+				                          ParameterSpec::ReadWriteAccess));
 
   /* ----- inputs ------- */
   ns->inputs.add("bottomUpIn",

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "Configuring htm_core tests")
 #   ${core_library}  references the htm_core  static library which includes depencancy libraries
 #
 
-set(CMAKE_VERBOSE_MAKEFILE ON) # toggle for cmake debug 
+set(CMAKE_VERBOSE_MAKEFILE OFF) # toggle for cmake debug 
 
 
 

--- a/src/test/unit/engine/CppRegionTest.cpp
+++ b/src/test/unit/engine/CppRegionTest.cpp
@@ -163,7 +163,7 @@ TEST(CppRegionTest, testYAML) {
   Network net;
   std::shared_ptr<Region> level1;
 
-  EXPECT_NO_THROW({level1 = net.addRegion("level1", "TestNode", params);});
+  level1 = net.addRegion("level1", "TestNode", params);
 
   net.initialize();
 
@@ -295,6 +295,7 @@ TEST(CppRegionTest, ValidateParameters) {
   EXPECT_STREQ("[\"false\", \"true\", \"false\", \"true\"]", a.toJSON().c_str());
 
   EXPECT_ANY_THROW(std::shared_ptr<Region> r2 = n.addRegion("testnode", "TestNode", "{invalid_field_name: \"abc\", dim: [2]}"));
+  
 }
 
 } // namespace testing

--- a/src/test/unit/engine/CppRegionTest.cpp
+++ b/src/test/unit/engine/CppRegionTest.cpp
@@ -39,7 +39,6 @@
 #include <algorithm>  // for max()
 #include <sstream>
 
-
 namespace testing {
 
 using namespace htm;
@@ -56,8 +55,8 @@ TEST(CppRegionTest, testCppLinkingFanIn) {
   Real64 *buffer2;
   Real64 *buffer3;
 
-  std::shared_ptr<Region> region1 = net.addRegion("region1", "TestNode", "{count: 64}");
-  std::shared_ptr<Region> region2 = net.addRegion("region2", "TestNode", "{count: 64}");
+  std::shared_ptr<Region> region1 = net.addRegion("region1", "TestNode", "dim: [64]");
+  std::shared_ptr<Region> region2 = net.addRegion("region2", "TestNode", "dim: [64]");
   std::shared_ptr<Region> region3 = net.addRegion("region3", "TestNode", "");
 
   net.link("region1", "region3");
@@ -159,7 +158,7 @@ TEST(CppRegionTest, testCppLinkingSDR) {
 
 
 TEST(CppRegionTest, testYAML) {
-  const char *params = "{count: 42, int32Param: 1234, real64Param: 23.1}";
+  const char *params = "{dim: [42], int32Param: 1234, real64Param: 23.1}";
 
   Network net;
   std::shared_ptr<Region> level1;
@@ -194,8 +193,7 @@ TEST(CppRegionTest, realmain) {
 
   size_t count1 = n.getRegions().size();
   EXPECT_TRUE(count1 == 0u);
-  std::shared_ptr<Region> level1 = n.addRegion("level1", "TestNode", "{count: 2}");
-
+  std::shared_ptr<Region> level1 = n.addRegion("level1", "TestNode", "{dim: [2]}");
 
   size_t count = n.getRegions().size();
   EXPECT_TRUE(count == 1u);
@@ -267,7 +265,7 @@ TEST(CppRegionTest, realmain) {
 TEST(CppRegionTest, RegionSerialization) {
 	Network n;
 
-	std::shared_ptr<Region> r1 = n.addRegion("testnode", "TestNode", "{count: 2}");
+  std::shared_ptr<Region> r1 = n.addRegion("testnode", "TestNode", "{dim: [2]}");
 
 	std::stringstream ss;
 	r1->save(ss);
@@ -277,5 +275,26 @@ TEST(CppRegionTest, RegionSerialization) {
 	EXPECT_EQ(*r1.get(), r2);
 }
 
+TEST(CppRegionTest, ValidateParameters) {
 
-} //ns
+  Value vm;
+  vm.parse("[true,false]");
+  EXPECT_TRUE(vm[0].as<bool>());
+  EXPECT_FALSE(vm[1].as<bool>());
+  EXPECT_STREQ("[\"true\", \"false\"]", vm.to_json().c_str());
+
+  bool buf[] = {true, false};
+  Array va(NTA_BasicType_Bool, &buf[0], 2);
+  EXPECT_STREQ("[\"true\", \"false\"]", va.toJSON().c_str());
+
+  Network n;
+  std::shared_ptr<Region> r1 = n.addRegion("testnode", "TestNode", "{dim: [2]}");
+  Array a;
+  // The default value for 'boolArrayParam' is an array [false, true, false, true].
+  r1->getParameterArray("boolArrayParam", a);
+  EXPECT_STREQ("[\"false\", \"true\", \"false\", \"true\"]", a.toJSON().c_str());
+
+  EXPECT_ANY_THROW(std::shared_ptr<Region> r2 = n.addRegion("testnode", "TestNode", "{invalid_field_name: \"abc\", dim: [2]}"));
+}
+
+} // namespace testing

--- a/src/test/unit/engine/RESTapiTest.cpp
+++ b/src/test/unit/engine/RESTapiTest.cpp
@@ -131,10 +131,10 @@ protected:
     // We do this here just to test that the server does shut down.
 
     client->Get("/stop");                                        // stop the server.
-    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // yield to give server time to stop
+    std::this_thread::sleep_for(std::chrono::milliseconds(500)); // yield to give server time to stop
 
     if (server.is_running()) {
-      ASSERT_TRUE(false) << "The server did not shut down with the /stop command within 100ms.";
+      ASSERT_TRUE(false) << "The server did not shut down with the /stop command within 500ms.";
       server.stop();  
     }
     serverThreadObj.join(); // wait until server thread has stopped.
@@ -206,8 +206,7 @@ TEST_F(RESTapiTest, example) {
   snprintf(message, sizeof(message), "/network/%s/region/tm/output/anomaly", id.c_str());
   res = client->Get(message);
   ASSERT_TRUE(res && res->status / 100 == 2) << " GET output message failed.";
-  EXPECT_STREQ(trim(res->body).c_str(), "{type: \"Real32\",data: [1]}")
-      << "Response to GET output request (The Anomaly Score)";
+  EXPECT_STREQ(trim(res->body).c_str(), "[1]") << "Response to GET output request (The Anomaly Score)";
 
 
 

--- a/src/test/unit/ntypes/ValueTest.cpp
+++ b/src/test/unit/ntypes/ValueTest.cpp
@@ -210,6 +210,25 @@ TEST(ValueTest, inserts) {
   EXPECT_ANY_THROW(vm[3]["hello"] = std::string("world"));
 }
 
+TEST(ValueTest, insertParsedValue) {
+  ValueMap vm;
+  std::string tree_src = "{param1: \"first node\", param2: \"second node\", param3: \"third node\"}";
+  vm.parse(tree_src);
+  // std::cout << "initial tree: " << vm << "\n";
+  EXPECT_STREQ(tree_src.c_str(), vm.to_json().c_str());
+
+  // Replace param2 with a sequence.
+  std::string insert_seq = "[ 1, 2, 3, 4 ]";
+  vm["param2"].parse(insert_seq);
+  EXPECT_STREQ("{param1: \"first node\", param2: [1, 2, 3, 4], param3: \"third node\"}", vm.to_json().c_str());
+
+  // Add a map to the sequence just added.
+  std::string insert_map = "{ a: \"value a\", b: \"value b\"}";
+  vm["param2"][4].parse(insert_map);
+  EXPECT_STREQ(
+      "{param1: \"first node\", param2: [1, 2, 3, 4, {a: \"value a\", b: \"value b\"}], param3: \"third node\"}",
+      vm.to_json().c_str());
+}
 
 TEST(ValueTest, ValueMapTest) {
   std::vector<UInt32> a = {1, 2, 3, 4};


### PR DESCRIPTION
Now an array of values can be configured as the default value for a parameter in the spec.
Allows syntax like  "[123, 5678, 97]" as a default value.