### PR TITLE
Added sqlite3 as third party package

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -125,3 +125,8 @@ include(digestpp.cmake)
 # cpp-httplib webserver and client
 include(cpp-httplib.cmake)
 
+#################
+#  Sqlite3  SQL Database
+include(sqlite3.cmake)
+
+

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -39,7 +39,7 @@
 # Note: on MSVC, run startupMSVC.bat after deleting the build folder.
 
 cmake_minimum_required(VERSION 3.7)
-project(htm_core CXX)
+project(htm_core CXX C)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 

--- a/external/bootstrap.cmake
+++ b/external/bootstrap.cmake
@@ -98,6 +98,7 @@ set(EXTERNAL_INCLUDES
 	${cereal_INCLUDE_DIRS}
 	${digestpp_INCLUDE_DIRS}
 	${cpp-httplib_INCLUDE_DIRS}
+	${sqlite3_INCLUDE_DIRS}
 	${common_INCLUDE_DIRS}
 	${REPOSITORY_DIR}/external/common/include
 )

--- a/external/sqlite3.cmake
+++ b/external/sqlite3.cmake
@@ -47,7 +47,7 @@ download_project(PROJ sqlite3
 # SQLite does not provide a CMakeList.txt to buld with so we provide the following lines to perform the compile here.
 # Since we are building here and not in the source folder, the library will show up directly under build/ThirdParty.
 set(CMAKE_C_COMPILE_OBJECT on)
-set(CMAKE_C_CREATE_STATIC_LIB on)
+set(CMAKE_C_CREATE_STATIC_LIBRARY on)
 set(SRCS ${sqlite3_SOURCE_DIR}/sqlite3.c ${sqlite3_SOURCE_DIR}/sqlite3.h)
 add_library(sqlite3 STATIC  ${SRCS} )
 target_compile_definitions(sqlite3 PRIVATE ${COMMON_COMPILER_DEFINITIONS})

--- a/external/sqlite3.cmake
+++ b/external/sqlite3.cmake
@@ -46,8 +46,6 @@ download_project(PROJ sqlite3
     
 # SQLite does not provide a CMakeList.txt to buld with so we provide the following lines to perform the compile here.
 # Since we are building here and not in the source folder, the library will show up directly under build/ThirdParty.
-set(CMAKE_C_COMPILE_OBJECT on)
-set(CMAKE_C_CREATE_STATIC_LIBRARY on)
 set(SRCS ${sqlite3_SOURCE_DIR}/sqlite3.c ${sqlite3_SOURCE_DIR}/sqlite3.h)
 add_library(sqlite3 STATIC  ${SRCS} )
 target_compile_definitions(sqlite3 PRIVATE ${COMMON_COMPILER_DEFINITIONS})

--- a/external/sqlite3.cmake
+++ b/external/sqlite3.cmake
@@ -1,0 +1,62 @@
+# -----------------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2019, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# -----------------------------------------------------------------------------
+# This downloads and builds the sqlite3 library.
+#
+# SQLite is a C-language library that implements a small, fast, self-contained, 
+#        high-reliability, full-featured, SQL database engine. SQLite is the most used 
+#        database engine in the world.
+#
+#            The current release is 3/32/3 (2020-06-18)
+#            The repository is at https://www.sqlite.org/2020/sqlite-autoconf-3320300.tar.gz
+#
+#
+if(EXISTS   ${REPOSITORY_DIR}/build/ThirdParty/share/sqlite3.tar.gz)
+    set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/sqlite3.tar.gz)
+else()
+    set(URL "https://www.sqlite.org/2020/sqlite-autoconf-3320300.tar.gz")
+endif()
+
+message(STATUS "Obtaining sqlite3")
+include(DownloadProject/DownloadProject.cmake)
+download_project(PROJ sqlite3
+	PREFIX ${EP_BASE}/sqlite3
+	URL ${URL}
+	GIT_SHALLOW ON
+	UPDATE_DISCONNECTED 1
+	QUIET
+	)
+    
+# SQLite does not provide a CMakeList.txt to buld with so we provide the following lines to perform the compile here.
+# Since we are building here and not in the source folder, the library will show up directly under build/ThirdParty.
+set(SRCS ${sqlite3_SOURCE_DIR}/sqlite3.c ${sqlite3_SOURCE_DIR}/sqlite3.h)
+add_library(sqlite3 STATIC  ${SRCS} )
+target_compile_definitions(sqlite3 PRIVATE ${COMMON_COMPILER_DEFINITIONS})
+
+set(sqlite3_INCLUDE_DIRS ${sqlite3_SOURCE_DIR}/include) 
+if (MSVC)
+  set(sqlite3_LIBRARIES   "${CMAKE_BINARY_DIR}$<$<CONFIG:Release>:/Release/sqlite3.lib>$<$<CONFIG:Debug>:/Debug/sqlite3.lib>") 
+else()
+  set(sqlite3_LIBRARIES   ${CMAKE_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}sqlite3${CMAKE_STATIC_LIBRARY_SUFFIX}) 
+endif()
+
+FILE(APPEND "${EXPORT_FILE_NAME}" "sqlite3_INCLUDE_DIRS@@@${sqlite3_INCLUDE_DIRS}\n")
+FILE(APPEND "${EXPORT_FILE_NAME}" "sqlite3_LIBRARIES@@@${sqlite3_LIBRARIES}\n")
+

--- a/external/sqlite3.cmake
+++ b/external/sqlite3.cmake
@@ -46,6 +46,8 @@ download_project(PROJ sqlite3
     
 # SQLite does not provide a CMakeList.txt to buld with so we provide the following lines to perform the compile here.
 # Since we are building here and not in the source folder, the library will show up directly under build/ThirdParty.
+set(CMAKE_C_COMPILE_OBJECT on)
+set(CMAKE_C_CREATE_STATIC_LIB on)
 set(SRCS ${sqlite3_SOURCE_DIR}/sqlite3.c ${sqlite3_SOURCE_DIR}/sqlite3.h)
 add_library(sqlite3 STATIC  ${SRCS} )
 target_compile_definitions(sqlite3 PRIVATE ${COMMON_COMPILER_DEFINITIONS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,7 @@ endif()
 set(src_combined_htmcore_source_archives
     ${src_lib_static}
     ${yaml_LIBRARIES}
+    ${sqlite3_LIBRARIES}
     ${Boost_LIBRARIES}
     ${common_LIBRARIES}
     )
@@ -288,6 +289,7 @@ else()
 	set(all_object_locations)
 	set(src_externLibs
             ${yaml_LIBRARIES}
+            ${sqlite3_LIBRARIES}
             ${Boost_LIBRARIES}
             ${common_LIBRARIES}
             )


### PR DESCRIPTION
The Sqlite3 package is now folded into the externs.  It will be downloaded and compiled into a library for both release and debug.  The .h is included in the include directories ${EXTERNAL_INCLUDES} and can be referenced as 'sqlite/sqlite.h'.  The library is included in 'externlibs' and is merged into the core library.   So, if you link with the htm.core library then it should be found.

Oh, you should not list sqlite.c or seqlite.h in src/CMakeLists.txt.

There are no unit tests included with this PR.  I expect that the PlotRegion project will include enough testing to tell if it can link properly.

