### PR TITLE
Allow inputs to be directly set by an app

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,8 @@ set(os_files
 )
 
 set(regions_files
+    htm/regions/InputRegion.cpp
+    htm/regions/InputRegion.hpp
     htm/regions/DateEncoderRegion.cpp
     htm/regions/DateEncoderRegion.hpp    
     htm/regions/ClassifierRegion.cpp

--- a/src/htm/engine/Network.cpp
+++ b/src/htm/engine/Network.cpp
@@ -315,8 +315,6 @@ std::shared_ptr<Link> Network::link(const std::string &srcRegionName,
                    const std::string &destInputName,
                    const size_t propagationDelay) {
 
-  std::shared_ptr<Region> srcRegion;
-
   // Find the regions
   auto itrSrc = regions_.find(srcRegionName);
   if (itrSrc == regions_.end()) {
@@ -360,7 +358,7 @@ std::shared_ptr<Link> Network::link(const std::string &srcRegionName,
       // This is our special source region for manually setting inputs
       // Get the data type from the destination Input object.
       NTA_BasicType type = destInput->getDataType();
-      std::shared_ptr<Output> output = std::make_shared<Output>(this, outputName, type);
+      std::shared_ptr<Output> output = std::make_shared<Output>(srcRegion.get(), outputName, type);
       srcRegion->outputs_[outputName] = output;
     } else {
       NTA_THROW << "Network::link -- output " << outputName << " does not exist on region " << srcRegionName;

--- a/src/htm/engine/RegionImplFactory.cpp
+++ b/src/htm/engine/RegionImplFactory.cpp
@@ -41,6 +41,7 @@
 #include <htm/regions/SPRegion.hpp>
 #include <htm/regions/TMRegion.hpp>
 #include <htm/regions/ClassifierRegion.hpp>
+#include <htm/regions/InputRegion.hpp>
 
 
 #include <htm/utils/Log.hpp>
@@ -90,16 +91,17 @@ RegionImplFactory &RegionImplFactory::getInstance() {
   if (instance.regionTypeMap.empty()) {
     // Create internal C++ regions
 
-	  instance.addRegionType("DateEncoderRegion", new RegisteredRegionImplCpp<DateEncoderRegion>());
+	  instance.addRegionType("DateEncoderRegion",  new RegisteredRegionImplCpp<DateEncoderRegion>());
     instance.addRegionType("ScalarEncoderRegion", new RegisteredRegionImplCpp<ScalarEncoderRegion>());
-    instance.addRegionType("RDSEEncoderRegion", new RegisteredRegionImplCpp<RDSEEncoderRegion>());
+    instance.addRegionType("RDSEEncoderRegion",  new RegisteredRegionImplCpp<RDSEEncoderRegion>());
     instance.addRegionType("TestNode",           new RegisteredRegionImplCpp<TestNode>());
-    instance.addRegionType("FileOutputRegion", new RegisteredRegionImplCpp<FileOutputRegion>());
-    instance.addRegionType("FileInputRegion",   new RegisteredRegionImplCpp<FileInputRegion>());
-    instance.addRegionType("DatabaseRegion", new RegisteredRegionImplCpp<DatabaseRegion>());
+    instance.addRegionType("FileOutputRegion",   new RegisteredRegionImplCpp<FileOutputRegion>());
+    instance.addRegionType("FileInputRegion",    new RegisteredRegionImplCpp<FileInputRegion>());
+    instance.addRegionType("DatabaseRegion",     new RegisteredRegionImplCpp<DatabaseRegion>());
     instance.addRegionType("SPRegion",           new RegisteredRegionImplCpp<SPRegion>());
     instance.addRegionType("TMRegion",           new RegisteredRegionImplCpp<TMRegion>());
     instance.addRegionType("ClassifierRegion",   new RegisteredRegionImplCpp<ClassifierRegion>());
+    instance.addRegionType("InputRegion",        new RegisteredRegionImplCpp<InputRegion>());
 
     // Renamed Regions
     instance.addRegionType("ScalarSensor", new RegisteredRegionImplCpp<ScalarEncoderRegion>());

--- a/src/htm/regions/InputRegion.cpp
+++ b/src/htm/regions/InputRegion.cpp
@@ -1,0 +1,71 @@
+/* ---------------------------------------------------------------------
+ * HTM Community Edition of NuPIC
+ * Copyright (C) 2019, Numenta, Inc.
+ *
+ * Author: David Keeney, July 2020, dkeeney@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ * --------------------------------------------------------------------- */
+
+/** @file
+ * Implementation of a network region that handles direct input to a region.
+ * This is not a normal region.  It does not need to be declared with an addRegion
+ * and is inferred when the name is used in a link.
+ * It facilitates the ability to directly set data into
+ * another region's input.  
+ *
+ *To use this, the user will declare a Link in the configuration which uses the 
+ * source region name of "INPUT" and a source name of their choosing.
+ * The destination region and destination input name is the target input to be set.
+ * The parameter 'dim' will specify the dimensions for the data.
+ *
+ * At runtime, between iterations, a C++ or Python app can then call 
+ *       net.setInputData( "INPUT", source_name, dest_region, dest_input, a)
+ *            where dest_region and dest_input are the names for the target and
+ *            'a' is an Array object containing the data to set.
+ * or on the REST api
+ *      PUT  /network/<id>/region/INPUT/input/<source name>
+ *                          The <data> will be in the body.
+ * The source name will identify the Link to use to direct the data to the target region's input. 
+ */
+
+#include <htm/regions/InputRegion.hpp>
+
+#include <htm/engine/Input.hpp>
+#include <htm/engine/Output.hpp>
+#include <htm/engine/Region.hpp>
+#include <htm/engine/Spec.hpp>
+#include <htm/ntypes/Array.hpp>
+#include <htm/utils/Log.hpp>
+
+#include <memory>
+
+
+
+InputRegion::InputRegion  (const ValueMap &params, Region *region){ }
+InputRegion::InputRegion(ArWrapper &wrapper, Region *region){ }
+
+virtual ~InputRegion::InputRegion() override { }
+
+/*static*/ Spec *InputRegion::createSpec() {
+  Spec *ns = new Spec();
+  ns->parseSpec(R"(
+  {name: "InputRegion"
+  } )");
+  return ns;
+}
+  
+void InputRegion::initialize() override { }
+
+void InputRegion::compute() override{ }
+

--- a/src/htm/regions/InputRegion.cpp
+++ b/src/htm/regions/InputRegion.cpp
@@ -38,8 +38,7 @@
  *                          The <data> will be in the body.
  * The source name will identify the Link to use to direct the data to the target region's input. 
  */
-
-#include <htm/regions/InputRegion.hpp>
+#include <memory>
 
 #include <htm/engine/Input.hpp>
 #include <htm/engine/Output.hpp>
@@ -48,11 +47,11 @@
 #include <htm/ntypes/Array.hpp>
 #include <htm/utils/Log.hpp>
 
-#include <memory>
+
+#include <htm/regions/InputRegion.hpp>
 
 
-
-InputRegion::InputRegion  (const ValueMap &params, Region *region){ }
+InputRegion::InputRegion(const ValueMap &params, Region *region) : RegionImpl(region) {}
 InputRegion::InputRegion(ArWrapper &wrapper, Region *region){ }
 
 virtual ~InputRegion::InputRegion() override { }

--- a/src/htm/regions/InputRegion.hpp
+++ b/src/htm/regions/InputRegion.hpp
@@ -72,7 +72,6 @@ public:
   void load_ar(Archive& ar) {
   }
 
-private:
 
 };
 

--- a/src/htm/regions/InputRegion.hpp
+++ b/src/htm/regions/InputRegion.hpp
@@ -1,0 +1,81 @@
+/* ---------------------------------------------------------------------
+ * HTM Community Edition of NuPIC
+ * Copyright (C) 2019, Numenta, Inc.
+ *
+ * Author: David Keeney, Nov. 2019   dkeeney@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ * --------------------------------------------------------------------- */
+
+/** @file
+ * Implementation of a network region that handles direct input to a region.
+ */
+
+#ifndef NTA_INPUTREGION_HPP
+#define NTA_INPUTREGION_HPP
+
+#include <string>
+#include <vector>
+
+#include <htm/engine/RegionImpl.hpp>
+#include <htm/ntypes/Value.hpp>
+#include <htm/types/Serializable.hpp>
+
+namespace htm {
+
+/**
+ * A network region that handles direct input to a region.
+ *
+ * @b Description
+ * The InputRegion is a region implementation that acts as a source of data flow for a 
+ * link that obtains data from an app. Conceptually the user declares a link which 
+ * declares the source region as "INPUT".  This will implicitly cause an InputRegion
+ * to be declared. The InputRegion acts as the placeholder for data being provided 
+ * from the app which the link will pass to the target input
+ */
+ 
+class InputRegion : public RegionImpl, Serializable {
+public:
+  InputRegion(const ValueMap &params, Region *region);
+  InputRegion(ArWrapper &wrapper, Region *region);
+
+  virtual ~InputRegion() override {}
+
+  static Spec *createSpec();
+  
+  virtual void initialize() override;
+
+  void compute() override;
+
+
+  CerealAdapter;  // see Serializable.hpp
+  // FOR Cereal Serialization
+  template<class Archive>
+  void save_ar(Archive& ar) const {
+  }
+  // FOR Cereal Deserialization
+  // NOTE: the Region Implementation must have been allocated
+  //       using the RegionImplFactory so that it is connected
+  //       to the Network and Region objects. This will populate
+  //       the region_ field in the Base class.
+  template<class Archive>
+  void load_ar(Archive& ar) {
+  }
+
+private:
+
+};
+
+} // namespace
+
+#endif // NTA_INPUTREGION_HPP


### PR DESCRIPTION
The problem is that we want to directly set an input from an app.  If there is no link attached, that input has no dimensions.  The dimensions must be set prior to initialization.

What his will do is require a special Link to be declared which knows that its input comes from the app rather than from another region.  This is sort of an adapter for direct input.

The advantage of using a link as the adapter is that it will allow link features on the input such as Fan-In and propitiation delay.

To declare a Link, use the special region id of "INPUT" and an 'input_name' of your choice for the source when declaring the link.  Then in your C++ or python app, pass data to the link by calling setInputData(input_name, data).

