### PR TITLE
Added the ability to access Spec and parameters as JSON from Python

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -19,6 +19,7 @@ Direct access to the algorithms APIs has changed:
 * `SDRClassifier` split into two classes: `Classifier` and `Predictor` with new API.
 * `Anomaly` class is now built into the `TemporalMemory`
 * `SpatialPooler` & `TemporalMemory` have many small changes, see below.
+* String parameters are defined in the Spec as type "String" rather than as a byte array.
 
 ## API breaking changes in this repo
 
@@ -140,3 +141,5 @@ mostly just a thin wrapper around the C++ library.
 
 - Most algorithms now accept SDR's instead of numpy arrays.
   Recommend reading the documentation, see `python -m pydoc htm`
+
+- Parameters containing strings were originally defined in the NetworkAPI Spec as a byte array (i.e. type "Byte" and count 0).  Byte arrays are now 8 bit integers and strings use type "String" and count 1.

--- a/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
+++ b/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
@@ -245,6 +245,7 @@ namespace htm_ext
             .def("askImplForOutputDimensions", &Region::askImplForOutputDimensions)
             .def("askImplForInputDimensions", &Region::askImplForInputDimensions);
                         
+        // These return the buffer's Array object
         py_Region.def("getInputArray", &Region::getInputData)
             .def("getOutputArray", &Region::getOutputData);
             
@@ -263,6 +264,9 @@ namespace htm_ext
                 return self;
         }));
 
+        py_Region.def("getSpec", &htm::Region::getSpec);
+        
+        py_Region.def("getParameters", &htm::Region::getParameters);
 
         py_Region.def("getParameterInt32", &Region::getParameterInt32)
             .def("getParameterUInt32", &Region::getParameterUInt32)
@@ -272,7 +276,8 @@ namespace htm_ext
             .def("getParameterReal64", &Region::getParameterReal64)
             .def("getParameterBool",   &Region::getParameterBool)
             .def("getParameterString", &Region::getParameterString)
-            .def("getParameterArray", &Region::getParameterArray);
+            .def("getParameterArray",  &Region::getParameterArray)
+            .def("getParameterJSON",   &Region::getParameterJSON);
 
         py_Region.def("getParameterArrayCount", &Region::getParameterArrayCount);
 
@@ -284,7 +289,8 @@ namespace htm_ext
             .def("setParameterReal64", &Region::setParameterReal64)
             .def("setParameterBool",   &Region::setParameterBool)
             .def("setParameterString", &Region::setParameterString)
-            .def("setParameterArray",  &Region::setParameterArray);
+            .def("setParameterArray",  &Region::setParameterArray)
+            .def("setParameterJSON",   &Region::setParameterJSON);
                 
                 
         py_Region.def("executeCommand", [](Region& r, const std::string& command, py::args args)
@@ -392,7 +398,6 @@ namespace htm_ext
         py_Network.def(py::init<>())
             .def(py::init<std::string>());
 
-
         py_Network.def("addRegion", (Region_Ptr_t (htm::Network::*)(
                     const std::string&,
                       const std::string&,
@@ -407,6 +412,9 @@ namespace htm_ext
                     &htm::Network::addRegion,
                     "add region for deserialization."
                     , py::arg("region"));
+                    
+        py_Network.def("configure", &htm::Network::configure);
+        py_Network.def("getSpecJSON", &htm::Network::getSpecJSON);
 
         py_Network.def("getRegions", &htm::Network::getRegions)
             .def("getRegion",          &htm::Network::getRegion)

--- a/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
+++ b/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
@@ -268,7 +268,8 @@ namespace htm_ext
         
         py_Region.def("getParameters", &htm::Region::getParameters);
 
-        py_Region.def("getParameterInt32", &Region::getParameterInt32)
+        py_Region.def("getParameterByte", &Region::getParameterByte)
+            .def("getParameterInt32",  &Region::getParameterInt32)
             .def("getParameterUInt32", &Region::getParameterUInt32)
             .def("getParameterInt64",  &Region::getParameterInt64)
             .def("getParameterUInt64", &Region::getParameterUInt64)
@@ -281,7 +282,8 @@ namespace htm_ext
 
         py_Region.def("getParameterArrayCount", &Region::getParameterArrayCount);
 
-        py_Region.def("setParameterInt32", &Region::setParameterInt32)
+        py_Region.def("setParameterByte", &Region::setParameterByte)
+            .def("setParameterInt32",  &Region::setParameterInt32)
             .def("setParameterUInt32", &Region::setParameterUInt32)
             .def("setParameterInt64",  &Region::setParameterInt64)
             .def("setParameterUInt64", &Region::setParameterUInt64)
@@ -472,7 +474,7 @@ namespace htm_ext
                 else if (info.format == "d") type = NTA_BasicType_Real64;
                 else if (info.format == py::format_descriptor<bool>::format()) type = NTA_BasicType_Bool;
                 else if (info.format == py::format_descriptor<Byte>::format()) type = NTA_BasicType_Byte;
-                else NTA_THROW << "setInputArray(): Unexpected data type in the array!  info.format=" << info.format;
+                else NTA_THROW << "setInputData(): Unexpected data type in the array!  info.format=" << info.format;
                 // for info.format codes, see https://docs.python.org/3.7/library/array.html
                 Array s(type, info.ptr, size);
                 std::cout << "src: " << s << std::endl;
@@ -502,6 +504,10 @@ namespace htm_ext
         py_Network.def_static("unregisterPyRegion", [](const std::string& typeName) {
                 htm::RegisteredRegionImplPy::unregisterPyRegion(typeName);
             });
+        py_Network.def_static("getRegistrations",
+                [](){ return htm::Network::getRegistrations();
+            });
+                
         py_Network.def_static("cleanup", &htm::Network::cleanup);
 
 

--- a/bindings/py/cpp_src/plugin/PyBindRegion.hpp
+++ b/bindings/py/cpp_src/plugin/PyBindRegion.hpp
@@ -97,19 +97,19 @@ namespace htm
         void compute() override;
         std::string executeCommand(const std::vector<std::string>& args, Int64 index) override;
 
-        size_t getParameterArrayCount(const std::string& name, Int64 index) override;
+        size_t getParameterArrayCount(const std::string& name, Int64 index) const override;
 
-        virtual Byte getParameterByte(const std::string& name, Int64 index);
-        virtual Int32 getParameterInt32(const std::string& name, Int64 index) override;
-        virtual UInt32 getParameterUInt32(const std::string& name, Int64 index) override;
-        virtual Int64 getParameterInt64(const std::string& name, Int64 index) override;
-        virtual UInt64 getParameterUInt64(const std::string& name, Int64 index) override;
-        virtual Real32 getParameterReal32(const std::string& name, Int64 index) override;
-        virtual Real64 getParameterReal64(const std::string& name, Int64 index) override;
-        virtual bool getParameterBool(const std::string& name, Int64 index) override;
-        virtual std::string getParameterString(const std::string& name, Int64 index) override;
+        virtual Byte getParameterByte(const std::string& name, Int64 index) const override;
+        virtual Int32 getParameterInt32(const std::string& name, Int64 index) const override;
+        virtual UInt32 getParameterUInt32(const std::string& name, Int64 index) const override;
+        virtual Int64 getParameterInt64(const std::string& name, Int64 index) const override;
+        virtual UInt64 getParameterUInt64(const std::string& name, Int64 index) const override;
+        virtual Real32 getParameterReal32(const std::string& name, Int64 index) const override;
+        virtual Real64 getParameterReal64(const std::string& name, Int64 index) const override;
+        virtual bool getParameterBool(const std::string& name, Int64 index) const override;
+        virtual std::string getParameterString(const std::string& name, Int64 index) const override;
 
-        virtual void setParameterByte(const std::string& name, Int64 index, Byte value);
+        virtual void setParameterByte(const std::string& name, Int64 index, Byte value) override;
         virtual void setParameterInt32(const std::string& name, Int64 index, Int32 value) override;
         virtual void setParameterUInt32(const std::string& name, Int64 index, UInt32 value) override;
         virtual void setParameterInt64(const std::string& name, Int64 index, Int64 value) override;
@@ -119,12 +119,12 @@ namespace htm
         virtual void setParameterBool(const std::string& name, Int64 index, bool value) override;
         virtual void setParameterString(const std::string& name, Int64 index, const std::string& value) override;
 
-        virtual void getParameterArray(const std::string& name, Int64 index, Array & array) override;
+        virtual void getParameterArray(const std::string& name, Int64 index, Array & array) const override;
         virtual void setParameterArray(const std::string& name, Int64 index, const Array & array) override;
 
         // Helper methods
         template <typename T>
-        T getParameterT(const std::string & name, Int64 index);
+        T getParameterT(const std::string & name, Int64 index) const;
 
         template <typename T>
         void setParameterT(const std::string & name, Int64 index, T value);

--- a/bindings/py/packaging/src/htm/bindings/regions/PyRegion.py
+++ b/bindings/py/packaging/src/htm/bindings/regions/PyRegion.py
@@ -235,7 +235,7 @@ class PyRegion(_PyRegionMeta):
 
 
   def getParameterArrayCount(self, name, index):
-    """Default implementation that return the length of the attribute.
+    """Default implementation that returns the length of the attribute.
 
     This default implementation goes hand in hand with
     :meth:`~nupic.bindings.regions.PyRegion.PyRegion.getParameterArray`.
@@ -251,8 +251,8 @@ class PyRegion(_PyRegionMeta):
     """
     if name.startswith('_'):
       raise Exception('Parameter name must not start with an underscore')
-
-    return len(self.parameters[name])
+    
+    return len(getattr(self, name))
 
 
   def getParameterArray(self, name, index, array):

--- a/py/htm/advanced/regions/ApicalTMPairRegion.py
+++ b/py/htm/advanced/regions/ApicalTMPairRegion.py
@@ -314,8 +314,8 @@ class ApicalTMPairRegion(PyRegion):
                 "implementation": {
                     "description": "Apical implementation",
                     "accessMode": "Create",
-                    "dataType": "Byte",
-                    "count": 0,
+                    "dataType": "String",
+                    "count": 1,
                     "constraints": ("enum: ApicalTiebreak, ApicalTiebreakCPP, ApicalDependent"),
                     "defaultValue": "ApicalTiebreakCPP",
                     "accessMode":"ReadWrite"

--- a/py/htm/advanced/regions/ColumnPoolerRegion.py
+++ b/py/htm/advanced/regions/ColumnPoolerRegion.py
@@ -142,14 +142,6 @@ class ColumnPoolerRegion(PyRegion):
                     dataType="Bool",
                     count=1,
                     defaultValue="false"),
-                learningTolerance=dict(
-                    description="How much variation in SDR size to accept when learning. "
-                                "Only has an effect if online learning is enabled. "
-                                "Should be at most 1 - inertiaFactor.",
-                    accessMode="ReadWrite",
-                    dataType="Real32",
-                    count=1,
-                    defaultValue="0"),
                 cellCount=dict(
                     description="Number of cells in this layer",
                     accessMode="Create",
@@ -325,8 +317,8 @@ class ColumnPoolerRegion(PyRegion):
                     description="Controls what type of cell output is placed into"
                                 " the default output 'feedForwardOutput'",
                     accessMode="Create",
-                    dataType="Byte",
-                    count=0,
+                    dataType="String",
+                    count=1,
                     constraints="enum: active,predicted,predictedActiveCells",
                     defaultValue="active"),
             ),

--- a/py/htm/advanced/regions/GridCellLocationRegion.py
+++ b/py/htm/advanced/regions/GridCellLocationRegion.py
@@ -244,18 +244,18 @@ class GridCellLocationRegion(PyRegion):
                 maxSynapsesPerSegment=dict(
                     description="The maximum number of synapses per segment",
                     accessMode="Create",
-                    dataType="UInt32",
+                    dataType="Int32",
                     count=1,
                     defaultValue="-1"
                 ),
                 bumpOverlapMethod=dict(
                     description="Specifies the firing rate of a cell when it's part of "
                                 "two bumps. ('probabilistic' or 'sum')",
-                    dataType="Byte",
+                    dataType="String",
                     accessMode="Create",
                     constraints=("enum: probabilistic, sum"),
                     defaultValue="probabilistic",
-                    count=0,
+                    count=1,
                 ),
                 learningMode=dict(
                     description="A boolean flag that indicates whether or not we should "

--- a/py/tests/networkapi/getParameters_test.py
+++ b/py/tests/networkapi/getParameters_test.py
@@ -1,0 +1,271 @@
+# ----------------------------------------------------------------------
+# HTM Community Edition of NuPIC
+# Copyright (C) 2020, Numenta, Inc.
+#
+# author: David Keeney, dkeeney@gmail.com, August 2020
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+# ----------------------------------------------------------------------
+
+""" 
+Unit tests for using NetworkAPI with python. 
+ This tests getSpecJSON(), getParameters(), and getParameterJSON( ).
+"""
+
+import numpy as np
+import unittest
+import json
+
+from htm.bindings.sdr import SDR
+from htm.bindings.engine_internal import Network,Region
+from htm.advanced.support.register_regions import registerAllAdvancedRegions
+
+class NetworkAPI_getParameters_Test(unittest.TestCase):
+  """ Unit tests for Network class. """
+
+    
+  def testGetSpec(self):
+    """
+    A test of the Network.getSpecJSON( ) function.
+    """
+    expected = """{"spec": "RDSEEncoderRegion",
+  "parameters": {
+    "activeBits": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "category": {
+      "type": "Bool",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "false"
+    }
+    "noise": {
+      "description": "amount of noise to add to the output SDR. 0.01 is 1%",
+      "type": "Real32",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "0.0"
+    }
+    "radius": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0.0"
+    }
+    "resolution": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0.0"
+    }
+    "seed": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "sensedValue": {
+      "description": "The value to encode. Overriden by input 'values'.",
+      "type": "Real64",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "0.0"
+    }
+    "size": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "sparsity": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0.0"
+    }
+  },
+  "inputs": {
+    "values": {
+      "description": "Values to encode. Overrides sensedValue.",
+      "type": "Real64",
+      "count": 1,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+  },
+  "outputs": {
+    "bucket": {
+      "description": "Quantized sample based on the radius. Becomes the title for this sample in Classifier.",
+      "type": "Real64",
+      "count": 1,
+      "regionLevel": 0,
+      "isDefaultOutput": 0
+    },
+    "encoded": {
+      "description": "Encoded bits. Not a true Sparse Data Representation (SP does that).",
+      "type": "SDR",
+      "count": 0,
+      "regionLevel": 1,
+      "isDefaultOutput": 1
+    },
+  }
+}"""
+    net = Network()
+    json_str = net.getSpecJSON("RDSEEncoderRegion");
+    self.assertEqual(json_str, expected)
+    
+    
+  def testGetParameters(self):
+    """
+    A test of the getParameters( ) and getParameterJSON() functions.
+    """
+    expected = """{
+  "activeBits": 200,
+  "category": false,
+  "noise": 0.010000,
+  "radius": 0.030000,
+  "resolution": 0.000150,
+  "seed": 2019,
+  "sensedValue": 0.000000,
+  "size": 1000,
+  "sparsity": 0.200000,
+}"""
+    net = Network();
+    encoder = net.addRegion("encoder", "RDSEEncoderRegion", "{size: 1000, sparsity: 0.2, radius: 0.03, seed: 2019, noise: 0.01}")
+    json_str = encoder.getParameters();
+    self.assertEqual(json_str, expected)
+    json_str = encoder.getParameterJSON("activeBits", False)
+    self.assertEqual(json_str, "200")
+    json_str = encoder.getParameterJSON("activeBits", True)
+    self.assertEqual(json_str, "{\"value\": 200, \"type\": \"UInt32\"}")
+    
+
+  def testGetParametersCustomRegions(self):
+
+    Network.cleanup();  # removes all previous registrations
+    registerAllAdvancedRegions()
+    json_list = Network.getRegistrations()
+    #print(json_list)
+    y = json.loads(json_list)
+    self.assertTrue("py.ColumnPoolerRegion" in y)
+    
+    net = Network();
+    #print(net.getSpecJSON("py.ColumnPoolerRegion"))
+    cp = net.addRegion("py.ColumnPoolerRegion", "py.ColumnPoolerRegion",
+                            """{ 
+	"activationThresholdDistal": 20,
+	"cellCount": 4096,
+	"connectedPermanenceDistal": 0.5,
+	"connectedPermanenceProximal": 0.5,
+	"initialDistalPermanence": 0.51,
+	"initialProximalPermanence": 0.6,
+	"minThresholdProximal": 5,
+	"sampleSizeDistal": 30,
+	"sampleSizeProximal": 10,
+	"sdrSize": 40,
+	"synPermDistalDec": 0.001,
+	"synPermDistalInc": 0.1,
+	"synPermProximalDec": 0.001,
+	"synPermProximalInc": 0.1
+}""")
+
+    # expected results from getParameters()  (in Spec order)
+    expected = """{
+  "learningMode": true,
+  "onlineLearning": false,
+  "cellCount": 4096,
+  "inputWidth": 16384,
+  "numOtherCorticalColumns": 0,
+  "sdrSize": 40,
+  "maxSdrSize": 0,
+  "minSdrSize": 0,
+  "synPermProximalInc": 0.100000,
+  "synPermProximalDec": 0.001000,
+  "initialProximalPermanence": 0.600000,
+  "sampleSizeProximal": 10,
+  "minThresholdProximal": 5,
+  "connectedPermanenceProximal": 0.500000,
+  "predictedInhibitionThreshold": 20.000000,
+  "synPermDistalInc": 0.100000,
+  "synPermDistalDec": 0.001000,
+  "initialDistalPermanence": 0.510000,
+  "sampleSizeDistal": 30,
+  "activationThresholdDistal": 20,
+  "connectedPermanenceDistal": 0.500000,
+  "inertiaFactor": 1.000000,
+  "seed": 42,
+  "defaultOutputType": "active",
+}""";
+
+    json_list = cp.getParameters();
+    #print(json_list)
+    self.assertEqual(json_list, expected)
+    
+
+  def testGetParametersGridCell(self):
+    # a test of arrays in parameters    
+    Network.cleanup();  # removes all previous registrations
+    registerAllAdvancedRegions()
+    json_list = Network.getRegistrations()
+    #print(json_list)
+    y = json.loads(json_list)
+    self.assertTrue("py.GridCellLocationRegion" in y)
+    
+    # only provide one orentation to shorten the test.  Full test in location_region_test.py
+    net = Network();
+    #print(net.getSpecJSON("py.GridCellLocationRegion"))
+    cp = net.addRegion("grid", "py.GridCellLocationRegion",
+          """{ 
+  "moduleCount": 1,
+  "cellsPerAxis": 10,
+  "scale": [1],
+  "orientation": [0.5],
+  "anchorInputSize": 1,
+  "activeFiringRate": 10 
+}""")
+
+    # expected results from getParameters()  (in Spec order)
+    expected = """{
+  "moduleCount": 1,
+  "cellsPerAxis": 10,
+  "scale": [1],
+  "orientation": [0.5],
+  "anchorInputSize": 1,
+  "activeFiringRate": 10.000000,
+  "bumpSigma": 0.181720,
+  "activationThreshold": 10,
+  "initialPermanence": 0.210000,
+  "connectedPermanence": 0.500000,
+  "learningThreshold": 10,
+  "sampleSize": 20,
+  "permanenceIncrement": 0.100000,
+  "permanenceDecrement": 0.000000,
+  "maxSynapsesPerSegment": -1,
+  "bumpOverlapMethod": "probabilistic",
+  "learningMode": false,
+  "dualPhase": true,
+  "dimensions": 2,
+  "seed": 42,
+}""";
+
+    json_list = cp.getParameters();
+    #print(json_list)
+    self.assertEqual(json_list, expected)
+    
+  
+if __name__ == "__main__":
+  unittest.main()

--- a/py/tests/networkapi/sinewave_test.py
+++ b/py/tests/networkapi/sinewave_test.py
@@ -26,6 +26,7 @@ import datetime
 import numpy as np
 import math
 import unittest
+import json
 
 from htm.bindings.sdr import SDR
 from htm.bindings.engine_internal import Network,Region
@@ -88,127 +89,8 @@ class NetworkAPI_SineWave_Test(unittest.TestCase):
     self.assertEqual(score, [1])
     #Note: Anomaly score will be 1 until there have been enough iterations to 'learn' the pattern.
     
-    
-  def testGetSpec(self):
-    """
-    A test of the Network.getSpecJSON( ) function.
-    """
-    expected = """{"spec": "RDSEEncoderRegion",
-  "parameters": {
-    "activeBits": {
-      "type": "UInt32",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "0"
-    }
-    "category": {
-      "type": "Bool",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "false"
-    }
-    "noise": {
-      "description": "amount of noise to add to the output SDR. 0.01 is 1%",
-      "type": "Real32",
-      "count": 1,
-      "access": "ReadWrite",
-      "defaultValue": "0.0"
-    }
-    "radius": {
-      "type": "Real32",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "0.0"
-    }
-    "resolution": {
-      "type": "Real32",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "0.0"
-    }
-    "seed": {
-      "type": "UInt32",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "0"
-    }
-    "sensedValue": {
-      "description": "The value to encode. Overriden by input 'values'.",
-      "type": "Real64",
-      "count": 1,
-      "access": "ReadWrite",
-      "defaultValue": "0.0"
-    }
-    "size": {
-      "type": "UInt32",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "0"
-    }
-    "sparsity": {
-      "type": "Real32",
-      "count": 1,
-      "access": "Create",
-      "defaultValue": "0.0"
-    }
-  },
-  "inputs": {
-    "values": {
-      "description": "Values to encode. Overrides sensedValue.",
-      "type": "Real64",
-      "count": 1,
-      "required": 0,
-      "regionLevel": 1,
-      "isDefaultInput": 1
-    },
-  },
-  "outputs": {
-    "bucket": {
-      "description": "Quantized sample based on the radius. Becomes the title for this sample in Classifier.",
-      "type": "Real64",
-      "count": 1,
-      "regionLevel": 0,
-      "isDefaultOutput": 0
-    },
-    "encoded": {
-      "description": "Encoded bits. Not a true Sparse Data Representation (SP does that).",
-      "type": "SDR",
-      "count": 0,
-      "regionLevel": 1,
-      "isDefaultOutput": 1
-    },
-  }
-}"""
-    net = Network()
-    json = net.getSpecJSON("RDSEEncoderRegion");
-    self.assertEqual(json, expected)
-    
-    
-  def testGetParameters(self):
-    """
-    A test of the getParameters( ) and getParameterJSON() functions.
-    """
-    expected = """{
-  "activeBits": 200,
-  "category": false,
-  "noise": 0.010000,
-  "radius": 0.030000,
-  "resolution": 0.000150,
-  "seed": 2019,
-  "sensedValue": 0.000000,
-  "size": 1000,
-  "sparsity": 0.200000,
-}"""
-    net = Network();
-    encoder = net.addRegion("encoder", "RDSEEncoderRegion", "{size: 1000, sparsity: 0.2, radius: 0.03, seed: 2019, noise: 0.01}")
-    json = encoder.getParameters();
-    self.assertEqual(json, expected)
-    json = encoder.getParameterJSON("activeBits", False)
-    self.assertEqual(json, "200")
-    json = encoder.getParameterJSON("activeBits", True)
-    self.assertEqual(json, "{\"value\": 200, \"type\": \"UInt32\"}")
-    
 
-
+    
+  
 if __name__ == "__main__":
   unittest.main()

--- a/py/tests/networkapi/sinewave_test.py
+++ b/py/tests/networkapi/sinewave_test.py
@@ -1,0 +1,214 @@
+# ----------------------------------------------------------------------
+# HTM Community Edition of NuPIC
+# Copyright (C) 2020, Numenta, Inc.
+#
+# author: David Keeney, dkeeney@gmail.com, July 2020
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+# ----------------------------------------------------------------------
+
+""" 
+Unit tests for using NetworkAPI with python. 
+Simular to the C++ example napi_hello.cpp
+"""
+
+import datetime
+import numpy as np
+import math
+import unittest
+
+from htm.bindings.sdr import SDR
+from htm.bindings.engine_internal import Network,Region
+
+EPOCHS = 3
+
+class NetworkAPI_SineWave_Test(unittest.TestCase):
+  """ Unit tests for Network class. """
+
+  def testNetwork(self):
+    """
+    A simple NetworkAPI example with three regions.
+    ///////////////////////////////////////////////////////////////
+    //
+    //                          .------------------.
+    //                         |    encoder        |
+    //        sinewave data--->|(RDSEEncoderRegion)|
+    //                         |                   |
+    //                         `-------------------'
+    //                                 |
+    //                         .-----------------.
+    //                         |     sp          |
+    //                         |  (SPRegion)     |
+    //                         |                 |
+    //                         `-----------------'
+    //                                 |
+    //                         .-----------------.
+    //                         |      tm         |
+    //                         |   (TMRegion)    |---->anomaly score
+    //                         |                 |
+    //                         `-----------------'
+    //
+    //////////////////////////////////////////////////////////////////
+    """
+    
+    """ Creating network instance. """
+    config = """
+        {network: [
+            {addRegion: {name: "encoder", type: "RDSEEncoderRegion", params: {size: 1000, sparsity: 0.2, radius: 0.03, seed: 2019, noise: 0.01}}},
+            {addRegion: {name: "sp", type: "SPRegion", params: {columnCount: 2048, globalInhibition: true}}},
+            {addRegion: {name: "tm", type: "TMRegion", params: {cellsPerColumn: 8, orColumnOutputs: true}}},
+            {addLink:   {src: "encoder.encoded", dest: "sp.bottomUpIn"}},
+            {addLink:   {src: "sp.bottomUpOut", dest: "tm.bottomUpIn"}}
+        ]}"""
+    net = Network();
+    net.configure(config);
+    
+    # iterate EPOCHS times
+    x = 0.00
+    for e in range(EPOCHS):
+      # Data is a sine wave,    (Note: first iteration is for x=0.01, not 0)
+      x += 0.01  # advance one step, 0.01 radians
+      s = math.sin(x)   # compute current sine as data.
+      #  feed data to RDSE encoder via its "sensedValue" parameter.
+      net.getRegion('encoder').setParameterReal64('sensedValue', s)
+      net.run(1)  # Execute one iteration of the Network object
+
+    # Retreive the final anomaly score from the TM object's 'anomaly' output. (as a single element numpy array)
+    score = np.array(net.getRegion('tm').getOutputArray('anomaly'))
+    self.assertEqual(score, [1])
+    #Note: Anomaly score will be 1 until there have been enough iterations to 'learn' the pattern.
+    
+    
+  def testGetSpec(self):
+    """
+    A test of the Network.getSpecJSON( ) function.
+    """
+    expected = """{"spec": "RDSEEncoderRegion",
+  "parameters": {
+    "activeBits": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "category": {
+      "type": "Bool",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "false"
+    }
+    "noise": {
+      "description": "amount of noise to add to the output SDR. 0.01 is 1%",
+      "type": "Real32",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "0.0"
+    }
+    "radius": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0.0"
+    }
+    "resolution": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0.0"
+    }
+    "seed": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "sensedValue": {
+      "description": "The value to encode. Overriden by input 'values'.",
+      "type": "Real64",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "0.0"
+    }
+    "size": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "sparsity": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0.0"
+    }
+  },
+  "inputs": {
+    "values": {
+      "description": "Values to encode. Overrides sensedValue.",
+      "type": "Real64",
+      "count": 1,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+  },
+  "outputs": {
+    "bucket": {
+      "description": "Quantized sample based on the radius. Becomes the title for this sample in Classifier.",
+      "type": "Real64",
+      "count": 1,
+      "regionLevel": 0,
+      "isDefaultOutput": 0
+    },
+    "encoded": {
+      "description": "Encoded bits. Not a true Sparse Data Representation (SP does that).",
+      "type": "SDR",
+      "count": 0,
+      "regionLevel": 1,
+      "isDefaultOutput": 1
+    },
+  }
+}"""
+    net = Network()
+    json = net.getSpecJSON("RDSEEncoderRegion");
+    self.assertEqual(json, expected)
+    
+    
+  def testGetParameters(self):
+    """
+    A test of the getParameters( ) and getParameterJSON() functions.
+    """
+    expected = """{
+  "activeBits": 200,
+  "category": false,
+  "noise": 0.010000,
+  "radius": 0.030000,
+  "resolution": 0.000150,
+  "seed": 2019,
+  "sensedValue": 0.000000,
+  "size": 1000,
+  "sparsity": 0.200000,
+}"""
+    net = Network();
+    encoder = net.addRegion("encoder", "RDSEEncoderRegion", "{size: 1000, sparsity: 0.2, radius: 0.03, seed: 2019, noise: 0.01}")
+    json = encoder.getParameters();
+    self.assertEqual(json, expected)
+    json = encoder.getParameterJSON("activeBits", False)
+    self.assertEqual(json, "200")
+    json = encoder.getParameterJSON("activeBits", True)
+    self.assertEqual(json, "{\"value\": 200, \"type\": \"UInt32\"}")
+    
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/src/htm/engine/Network.cpp
+++ b/src/htm/engine/Network.cpp
@@ -580,6 +580,13 @@ std::shared_ptr<Region> Network::getRegion(const std::string& name) const {
   return itr->second;
 }
 
+std::string Network::getSpecJSON(const std::string &type) {
+  RegionImplFactory &factory = RegionImplFactory::getInstance();
+  const std::shared_ptr<Spec> spec = factory.getSpec(type);
+  return spec->toString();
+}
+
+
 
 std::vector<std::shared_ptr<Link>> Network::getLinks() const {
   std::vector<std::shared_ptr<Link>> links;

--- a/src/htm/engine/Network.cpp
+++ b/src/htm/engine/Network.cpp
@@ -798,6 +798,11 @@ void Network::registerRegion(const std::string name, RegisteredRegionImpl *wrapp
 void Network::unregisterRegion(const std::string name) {
 	RegionImplFactory::unregisterRegion(name);
 }
+
+std::string Network::getRegistrations() {
+  return RegionImplFactory::getRegistrations();
+}
+
 void Network::cleanup() {
     RegionImplFactory::cleanup();
 }

--- a/src/htm/engine/Network.hpp
+++ b/src/htm/engine/Network.hpp
@@ -117,6 +117,7 @@ public:
    *  On errors it throws an exception.
    */
   void configure(const std::string &yaml);
+  std::string getSpecJSON(const std::string &type);
 
 
   /**

--- a/src/htm/engine/Network.hpp
+++ b/src/htm/engine/Network.hpp
@@ -117,7 +117,19 @@ public:
    *  On errors it throws an exception.
    */
   void configure(const std::string &yaml);
-  std::string getSpecJSON(const std::string &type);
+  
+  /**
+   * Return the Spec for the region type as a JSON string.
+   * Note that the region does NOT have to have been previously added with addRegion( ).
+   *
+   * @param region_type  The name of the region implementation.
+   *                     This is the name of one of the built-in Regions (usually class name) 
+   *                     or the region type given to a custom region that has been registered.  
+   *                     Python implemented regions are registered as the class name with
+   *                     'py.' prepended.
+   * @returns  A JSON string containing the Spec.
+   */
+  std::string getSpecJSON(const std::string &region_type);
 
 
   /**
@@ -464,6 +476,12 @@ public:
    * Removes a region implementation from the RegionImplFactory's list of packages
    */
   static void unregisterRegion(const std::string name);
+  
+  /*
+   * Returns a JSON string containing a list of registered region types.
+   *
+   */
+  static std::string getRegistrations();
 
   /*
    * Removes all region registrations in RegionImplFactory.

--- a/src/htm/engine/RESTapi.cpp
+++ b/src/htm/engine/RESTapi.cpp
@@ -188,7 +188,7 @@ std::string RESTapi::get_param_request(const std::string &id,
     itr->second.t = time(0);
 
     std::string response;
-    response = itr->second.net->getRegion(region_name)->getParameterJSON(param_name, "result");
+    response = "{\"result\": " + itr->second.net->getRegion(region_name)->getParameterJSON(param_name) + "}";
 
     return response;
   } catch (Exception &e) {

--- a/src/htm/engine/Region.hpp
+++ b/src/htm/engine/Region.hpp
@@ -108,16 +108,6 @@ public:
    */
   const std::shared_ptr<Spec> &getSpec() const { return spec_; }
 
-  /**
-   * Get the Spec of a region type without an instance.
-   *
-   * @param nodeType
-   *        A region type as a string
-   *
-   * @returns The Spec that describes this region type
-   */
-  static const std::shared_ptr<Spec> &
-  getSpecFromType(const std::string &nodeType);
 
   /**
    * @}
@@ -127,6 +117,12 @@ public:
    * @{
    *
    */
+   
+  /** 
+   * Get all parameter values for the region as a JSON string.
+   * @returns a JSON string.
+   */
+  std::string getParameters() const;
 
   /**
    * Get the parameter value as a specific type.
@@ -143,7 +139,20 @@ public:
   Real32 getParameterReal32(const std::string &name) const;
   Real64 getParameterReal64(const std::string &name) const;
   bool getParameterBool(const std::string &name) const;
-  std::string getParameterJSON(const std::string &name, const std::string &tag) const;
+
+  /**
+   * Get the parameter value as JSON
+   * if the tag is not given, it just returns the JSON encoded value.
+   * @param name
+   *        The name of the parameter
+   *
+   * @param tag  (optional)
+   *       if the tag IS NOT given (or blank), it returns just the JSON encoded value.
+   *       if the tag IS given, it returns <tag>: {"value": <JSON value>, "type": <type>}
+   *
+   * @returns The value of the parameter
+   */
+  std::string getParameterJSON(const std::string &name, bool withType = false) const;
 
   /**
    * Set the parameter value of a specific type.

--- a/src/htm/engine/Region.hpp
+++ b/src/htm/engine/Region.hpp
@@ -132,6 +132,7 @@ public:
    *
    * @returns The value of the parameter
    */
+  Byte getParameterByte(const std::string &name) const;
   Int32 getParameterInt32(const std::string &name) const;
   UInt32 getParameterUInt32(const std::string &name) const;
   Int64 getParameterInt64(const std::string &name) const;
@@ -163,6 +164,7 @@ public:
    * @param value
    *        The value of the parameter
    */
+  void setParameterByte(const std::string &name, Byte value);
   void setParameterInt32(const std::string &name, Int32 value);
   void setParameterUInt32(const std::string &name, UInt32 value);
   void setParameterInt64(const std::string &name, Int64 value);
@@ -241,7 +243,7 @@ public:
    * @param name
    *        The name of the parameter
 	 */
-  size_t getParameterArrayCount(const std::string &name);
+  size_t getParameterArrayCount(const std::string &name) const;
 
 
   /**

--- a/src/htm/engine/RegionImpl.cpp
+++ b/src/htm/engine/RegionImpl.cpp
@@ -45,7 +45,7 @@ std::string RegionImpl::getName() const { return region_->getName(); }
 // overridden by subclasses.
 
 #define getParameterInternalT(MethodT, Type)                                                                           \
-  Type RegionImpl::getParameter##MethodT(const std::string &name, Int64 index) {                                       \
+  Type RegionImpl::getParameter##MethodT(const std::string &name, Int64 index) const {                                       \
     if (!region_->getSpec()->parameters.contains(name))                                                                \
       NTA_THROW << "getParameter" #Type ": Region type " << getType() << ", parameter " << name                        \
                 << " does not exist in region spec";                                                                   \
@@ -59,10 +59,12 @@ std::string RegionImpl::getName() const { return region_->getName(); }
 
 #define getParameterT(Type) getParameterInternalT(Type, Type)
 
+getParameterT(Byte);
 getParameterT(Int32);
 getParameterT(UInt32);
 getParameterT(Int64);
-getParameterT(UInt64) getParameterT(Real32);
+getParameterT(UInt64); 
+getParameterT(Real32);
 getParameterT(Real64);
 getParameterInternalT(Bool, bool);
 
@@ -83,6 +85,7 @@ getParameterInternalT(Bool, bool);
 
 #define setParameterT(Type) setParameterInternalT(Type, Type)
 
+setParameterT(Byte);
 setParameterT(Int32);
 setParameterT(UInt32);
 setParameterT(Int64);
@@ -91,7 +94,7 @@ setParameterT(Real32);
 setParameterT(Real64);
 setParameterInternalT(Bool, bool);
 
-void RegionImpl::getParameterArray(const std::string &name, Int64 index, Array &array) {
+void RegionImpl::getParameterArray(const std::string &name, Int64 index, Array &array) const {
   if (!region_->getSpec()->parameters.contains(name))
     NTA_THROW << "setParameterArray: parameter " << name << " does not exist in Spec";
   ParameterSpec p = region_->getSpec()->parameters.getByName(name);
@@ -124,7 +127,7 @@ void RegionImpl::setParameterString(const std::string &name, Int64 index, const 
             << " but is not implemented.";
 }
 
-std::string RegionImpl::getParameterString(const std::string &name, Int64 index) {
+std::string RegionImpl::getParameterString(const std::string &name, Int64 index) const {
   if (!region_->getSpec()->parameters.contains(name))
     NTA_THROW << "getParameterString: parameter " << name << " does not exist in Spec";
   ParameterSpec p = region_->getSpec()->parameters.getByName(name);
@@ -137,7 +140,7 @@ std::string RegionImpl::getParameterString(const std::string &name, Int64 index)
   return "";
 }
 
-size_t RegionImpl::getParameterArrayCount(const std::string &name, Int64 index) {
+size_t RegionImpl::getParameterArrayCount(const std::string &name, Int64 index) const {
   // Default implementation for RegionImpls with no array parameters
   // that have a dynamic length.
   // std::map<std::string, ParameterSpec*>::iterator i =

--- a/src/htm/engine/RegionImpl.hpp
+++ b/src/htm/engine/RegionImpl.hpp
@@ -169,18 +169,19 @@ public:
 
 
   /* ------- Parameter support in the base class. ---------*/
-  // The default implementation of all of these methods goes through
-  // set/getParameterFromBuffer, which is compatible with NuPIC 1.
-  // RegionImpl subclasses may override for higher performance.
 
-  virtual Int32 getParameterInt32(const std::string &name, Int64 index);
-  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index);
-  virtual Int64 getParameterInt64(const std::string &name, Int64 index);
-  virtual UInt64 getParameterUInt64(const std::string &name, Int64 index);
-  virtual Real32 getParameterReal32(const std::string &name, Int64 index);
-  virtual Real64 getParameterReal64(const std::string &name, Int64 index);
-  virtual bool getParameterBool(const std::string &name, Int64 index);
+  virtual Byte getParameterByte(const std::string& name, Int64 index) const;
+  virtual Int32 getParameterInt32(const std::string &name, Int64 index) const;
+  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index) const;
+  virtual Int64 getParameterInt64(const std::string &name, Int64 index) const;
+  virtual UInt64 getParameterUInt64(const std::string &name, Int64 index) const;
+  virtual Real32 getParameterReal32(const std::string &name, Int64 index) const;
+  virtual Real64 getParameterReal64(const std::string &name, Int64 index) const;
+  virtual bool getParameterBool(const std::string &name, Int64 index) const;
 
+
+  virtual void setParameterByte(const std::string &name, Int64 index,
+                                 Byte value);
   virtual void setParameterInt32(const std::string &name, Int64 index,
                                  Int32 value);
   virtual void setParameterUInt32(const std::string &name, Int64 index,
@@ -196,14 +197,23 @@ public:
   virtual void setParameterBool(const std::string &name, Int64 index,
                                 bool value);
 
-  virtual void getParameterArray(const std::string &name, Int64 index,
-                                 Array &array);
+  virtual void getParameterArray(const std::string &name, Int64 index, Array &array) const;
   virtual void setParameterArray(const std::string &name, Int64 index,
                                  const Array &array);
 
   virtual void setParameterString(const std::string &name, Int64 index,
                                   const std::string &s);
-  virtual std::string getParameterString(const std::string &name, Int64 index);
+  virtual std::string getParameterString(const std::string &name, Int64 index) const;
+
+  /**
+   * Array-valued parameters may have a size determined at runtime.
+   * This method returns the number of elements in the named parameter.
+   * If parameter is not an array type, may throw an exception or return 1.
+   *
+   * Must be implemented only if the node has one or more array
+   * parameters with a dynamically-determined length.
+   */
+  virtual size_t getParameterArrayCount(const std::string &name, Int64 index) const;
 
   /* -------- Methods that must be implemented by subclasses -------- */
 
@@ -277,15 +287,6 @@ public:
   virtual Dimensions askImplForOutputDimensions(const std::string &name);
 
 
-  /**
-   * Array-valued parameters may have a size determined at runtime.
-   * This method returns the number of elements in the named parameter.
-   * If parameter is not an array type, may throw an exception or return 1.
-   *
-   * Must be implemented only if the node has one or more array
-   * parameters with a dynamically-determined length.
-   */
-  virtual size_t getParameterArrayCount(const std::string &name, Int64 index);
 
   /**
    * Set Global dimensions on a region.

--- a/src/htm/engine/RegionImplFactory.cpp
+++ b/src/htm/engine/RegionImplFactory.cpp
@@ -83,6 +83,21 @@ void RegionImplFactory::unregisterRegion(const std::string nodeType) {
   }
 }
 
+std::string RegionImplFactory::getRegistrations() {
+  RegionImplFactory& instance = getInstance();  // force load of built-ins.
+  
+  std::string json = "{\n";
+  for (auto iter = instance.regionTypeMap.begin(); iter != instance.regionTypeMap.end(); ++iter) {
+     if (iter->first != "RawInput") {
+       if (json.size() > 3) json += ",\n";
+       json += "  \""+iter->first+"\": "
+               "{\"class\": \""+iter->second->className()+"\""
+               ", \"module\": \""+iter->second->moduleName()+"\"}";
+     }
+  }
+  json += "\n}";
+  return json;
+}
 
 RegionImplFactory &RegionImplFactory::getInstance() {
   static RegionImplFactory instance;

--- a/src/htm/engine/RegionImplFactory.hpp
+++ b/src/htm/engine/RegionImplFactory.hpp
@@ -76,6 +76,8 @@ public:
 
   // Allows the user to unregister region types
   static void unregisterRegion(const std::string regionType);
+  
+  static std::string getRegistrations();
 
 private:
   RegionImplFactory(){};

--- a/src/htm/engine/RegisteredRegionImplCpp.hpp
+++ b/src/htm/engine/RegisteredRegionImplCpp.hpp
@@ -64,7 +64,7 @@ namespace htm
   template <class T>
   class RegisteredRegionImplCpp: public RegisteredRegionImpl {
     public:
-      RegisteredRegionImplCpp(const std::string& classname="", const std::string& module="")
+      RegisteredRegionImplCpp(const std::string& classname=typeid(T).name(), const std::string& module="")
 	  		: RegisteredRegionImpl(classname, module) {
 	  }
 

--- a/src/htm/engine/Spec.cpp
+++ b/src/htm/engine/Spec.cpp
@@ -107,12 +107,15 @@ bool InputSpec::operator==(const InputSpec &o) const {
          count == o.count && description == o.description;
 }
 std::ostream& operator<< (std::ostream& out, const InputSpec& self) {
-   out << "      description: " << self.description << "\n"
-       << "      type: " << BasicType::getName(self.dataType) << "\n"
-       << "      count: " << self.count << "\n"
-       << "      required: " << self.required << "\n"
-       << "      regionLevel: " << self.regionLevel << "\n"
-       << "      isDefaultInput: " << self.isDefaultInput << "\n";
+   out << "{\n";
+   if (!self.description.empty())
+     out << "      \"description\": \"" << self.description << "\",\n";
+   out << "      \"type\": \"" << BasicType::getName(self.dataType) << "\",\n";
+   out << "      \"count\": " << self.count << ",\n";
+   out << "      \"required\": " << self.required << ",\n";
+   out << "      \"regionLevel\": " << self.regionLevel << ",\n";
+   out << "      \"isDefaultInput\": " << self.isDefaultInput << "\n";
+   out << "    }";
    return out;
 }
 
@@ -130,11 +133,14 @@ bool OutputSpec::operator==(const OutputSpec &o) const {
          description == o.description;
 }
 std::ostream& operator<< (std::ostream& out, const OutputSpec& self) {
-   out << "      description: " << self.description << "\n"
-       << "      type: " << BasicType::getName(self.dataType) << "\n"
-       << "      count: " << self.count << "\n"
-       << "      regionLevel: " << self.regionLevel << "\n"
-       << "      isDefaultInput: " << self.isDefaultOutput << "\n";
+  out << "{\n";
+   if (!self.description.empty())
+     out << "      \"description\": \"" << self.description << "\",\n";
+   out << "      \"type\": \"" << BasicType::getName(self.dataType) << "\",\n";
+   out << "      \"count\": " << self.count << ",\n";
+   out << "      \"regionLevel\": " << self.regionLevel << ",\n";
+   out << "      \"isDefaultOutput\": " << self.isDefaultOutput << "\n";
+   out << "    }";
    return out;
 }
 
@@ -142,6 +148,11 @@ CommandSpec::CommandSpec(std::string description)
     : description(std::move(description)) {}
 bool CommandSpec::operator==(const CommandSpec &o) const {
   return description == o.description;
+}
+std::ostream& operator<< (std::ostream& out, const CommandSpec& self) {
+   if (!self.description.empty())
+     out << "      \"description\": \"" << self.description << "\",\n";
+   return out;
 }
 
 ParameterSpec::ParameterSpec(std::string description, NTA_BasicType dataType,
@@ -157,18 +168,20 @@ bool ParameterSpec::operator==(const ParameterSpec &o) const {
          defaultValue == o.defaultValue && accessMode == o.accessMode;
 }
 std::ostream& operator<< (std::ostream& out, const ParameterSpec& self) {
-    out << "      description: " << self.description << "\n"
-        << "      type: " << BasicType::getName(self.dataType) << "\n"
-        << "      count: " << self.count << "\n"
-        << "      access: ";
+    if (!self.description.empty())
+      out << "      \"description\": \"" << self.description << "\",\n";
+    out << "      \"type\": \"" << BasicType::getName(self.dataType) << "\",\n";
+    out << "      \"count\": " << self.count << ",\n";
+    out << "      \"access\": ";
     switch(self.accessMode) {
-    case ParameterSpec::CreateAccess:  out << "CreateAccess\n"; break;
-    case ParameterSpec::ReadOnlyAccess: out << "ReadOnlyAccess\n"; break;
-    case ParameterSpec::ReadWriteAccess: out << "ReadWriteAccess\n"; break;
-    default: out << "UnknownAccess\n"; break;
+    case ParameterSpec::CreateAccess:  out << "\"Create\",\n"; break;
+    case ParameterSpec::ReadOnlyAccess: out << "\"ReadOnly\",\n"; break;
+    case ParameterSpec::ReadWriteAccess: out << "\"ReadWrite\",\n"; break;
+    default: out << "\"UnknownAccess\",\n"; break;
     }
-    out << "      defaultValue: " << self.defaultValue << "\n";
-    out << "      constraints: " << self.constraints << "\n";
+    if (!self.constraints.empty())
+      out << "      \"constraints\": \"" << self.constraints << "\",\n";
+    out << "      \"defaultValue\": \"" << self.defaultValue << "\"";
     return out;
 }
 
@@ -176,37 +189,44 @@ std::string Spec::toString() const {
   // TODO -- minimal information here; fill out with the rest of
   // the parameter spec information
   std::stringstream ss;
-  ss << "Spec: " << this->name  << "\n";
-  ss << "  Description:"  << this->description << "\n";
+  ss << "{\"spec\": \"" << this->name  << "\",\n";
+  if (!this->description.empty())
+    ss << "  \"description\": \""  << this->description << "\",\n";
 
-  ss << "  Parameters:" << "\n";
+  ss << "  \"parameters\": {\n";
   for (size_t i = 0; i < parameters.getCount(); ++i) {
     const std::pair<std::string, ParameterSpec> &item = parameters.getByIndex(i);
-    ss << "    " << item.first << ":\n";
+    ss << "    \"" << item.first << "\": {\n";
     ss << item.second << "\n";
+    ss << "    }\n";
+  }
+  ss << "  },\n";
+  
+  if (commands.getCount() > 0) {
+    ss << "  \"commands\": {\n";
+    for (size_t i = 0; i < commands.getCount(); ++i) {
+      ss << "    \"" << commands.getByIndex(i).first << "\": \""
+         << commands.getByIndex(i).second.description << "\",\n";
+    }
+    ss << "    },\n";
   }
 
-  ss << "  Inputs:" << "\n";
+
+  ss << "  \"inputs\": {\n";
   for (size_t i = 0; i < inputs.getCount(); ++i) {
     const std::pair<std::string, InputSpec> &item = inputs.getByIndex(i);
-    ss << "    " << item.first << ":\n";
-    ss << item.second << "\n";
+    ss << "    \"" << item.first << "\": "  << item.second << ",\n";
   }
+  ss << "  },\n";
 
-  ss << "Outputs:" << "\n";
+  ss << "  \"outputs\": {\n";
   for (size_t i = 0; i < outputs.getCount(); ++i) {
     const std::pair<std::string, OutputSpec> &item = outputs.getByIndex(i);
-    ss << "    " << item.first << ":\n";
-    ss << item.second << "\n";
+    ss << "    \"" << item.first << "\": " << item.second << ",\n";
   }
-
-  if (commands.getCount() > 0) {
-    ss << "  Commands:" << "\n";
-    for (size_t i = 0; i < commands.getCount(); ++i) {
-      ss << "    " << commands.getByIndex(i).first << ": "
-         << commands.getByIndex(i).second.description << "\n";
-    }
-  }
+  ss << "  }\n";
+  ss << "}";
+  
   return ss.str();
 }
 
@@ -222,7 +242,7 @@ std::ostream& operator<< (std::ostream& out, const Spec& self) {
 // Field order does not matter.
 //
 // Expected yaml layout:
-//    name: <the region's name>                                     (string, default "")
+//    spec: <the region's name>                                     (string, default "")
 //    description: "text describing the region."                    (string, default "")
 //    parameters:
 //      <name>:                                         repeat for each parameter
@@ -232,6 +252,9 @@ std::ostream& operator<< (std::ostream& out, const Spec& self) {
 //        constraints: <constraint text>,                           (string, default "" )
 //        defaultValue: <as quoted JSON string>,                    (string, default "0")
 //        access: <one of "Create", "ReadOnly", "ReadWrite">        (enum, default "Create")
+//    commands:
+//      <name>:                                         repeat for each command
+//        description: "description of command",                    (string, default "")
 //    inputs:
 //      <name>:                                         repeat for each input
 //        description: "description of input",                      (string, default "")
@@ -247,9 +270,6 @@ std::ostream& operator<< (std::ostream& out, const Spec& self) {
 //        count: <"0" if variable array width, else fixed width>    (size_t, default "0")
 //        isRegionLevel: <true if inherits region dimensions>,      (bool, default "false")
 //        isDefaultOutput: <if true, assumed output for region>     (bool, default "false")
-//    commands:
-//      <name>:                                         repeat for each command
-//        description: "description of command",                    (string, default "")
 //
 void Spec::parseSpec(const std::string &yaml) {
   Value tree;
@@ -261,7 +281,7 @@ void Spec::parseSpec(const std::string &yaml) {
     std::string the_name;
     std::string itm;
     try {
-      if (category == "name") {
+      if (category == "name" || category == "spec") {
         name = category_pair.second.str();
       } else if (category == "description")
         description = category_pair.second.str();
@@ -343,6 +363,13 @@ void Spec::parseSpec(const std::string &yaml) {
                         << "outputs '" << the_name << "'.";
           }
           outputs.add(the_name, par);
+        }
+      } else if (category == "commands") {
+        for (auto field_par : category_pair.second) {
+          the_name = field_par.first;
+          CommandSpec par;
+          par.description = field_par.second.str();
+          commands.add(the_name, par);
         }
       } else
         NTA_THROW << "Unexpected category: in spec for " << name << "::.";

--- a/src/htm/ntypes/Array.hpp
+++ b/src/htm/ntypes/Array.hpp
@@ -184,7 +184,7 @@ public:
   /**
    * Initialize by copying in from a raw C-type buffer.  See ArrayBase
    */
-  Array(NTA_BasicType type, void *buffer, size_t count)
+  Array(NTA_BasicType type, const void *buffer, size_t count)
       : ArrayBase(type, buffer, count) {}
 
   /**

--- a/src/htm/ntypes/ArrayBase.cpp
+++ b/src/htm/ntypes/ArrayBase.cpp
@@ -592,7 +592,7 @@ void ArrayBase::fromValue(const Value &vm_) {
           dim.push_back(vm1[i].as<UInt>());
         }
       } else {
-        dim.push_back(num);
+        dim.push_back(static_cast<UInt>(num));
       }
       allocateBuffer(dim);
     } else {

--- a/src/htm/ntypes/ArrayBase.cpp
+++ b/src/htm/ntypes/ArrayBase.cpp
@@ -36,7 +36,7 @@ namespace htm {
 /**
  * This makes a deep copy of the buffer so this class will own the buffer.
  */
-ArrayBase::ArrayBase(NTA_BasicType type, void *buffer, size_t count) {
+ArrayBase::ArrayBase(NTA_BasicType type, const void *buffer, size_t count) {
   if (!BasicType::isValid(type)) {
     NTA_THROW << "Invalid NTA_BasicType " << type << " used in array constructor";
   }
@@ -45,14 +45,14 @@ ArrayBase::ArrayBase(NTA_BasicType type, void *buffer, size_t count) {
   if (has_buffer()) {
     if (type == NTA_BasicType_Str) {
       std::string *ptr1 = reinterpret_cast<std::string *>(getBuffer());
-      std::string *ptr2 = reinterpret_cast<std::string *>(buffer);
+      const std::string *ptr2 = reinterpret_cast<const std::string *>(buffer);
       for (size_t i = 0; i < count; i++) {
         ptr1[i] = ptr2[i];
       }
     } else {
       // Warning: for NTA_BasicType_Bool, if the buffer came from the internal buffer of a vector
       //          the element size is not known for sure. It might be optimized to store them as bits.
-      std::memcpy(reinterpret_cast<char *>(getBuffer()), reinterpret_cast<char *>(buffer),
+      std::memcpy(reinterpret_cast<char *>(getBuffer()), reinterpret_cast<const char *>(buffer),
                   count * BasicType::getSize(type));
     }
   }

--- a/src/htm/ntypes/ArrayBase.hpp
+++ b/src/htm/ntypes/ArrayBase.hpp
@@ -61,7 +61,7 @@ namespace htm
      * Caller frees buffer when no longer needed.
      * For NTA_BasicType_SDR, use ArrayBase(SDR&) so dimensions are set.
      */
-    ArrayBase(NTA_BasicType type, void *buffer, size_t count);
+    ArrayBase(NTA_BasicType type, const void *buffer, size_t count);
 
 
     /**

--- a/src/htm/ntypes/Value.cpp
+++ b/src/htm/ntypes/Value.cpp
@@ -329,7 +329,8 @@ std::string Value::str() const {
 }
 const char *Value::c_str() const {
   NTA_CHECK(core_->type_ == Value::Category::Scalar) 
-    << ((core_->type_ == Value::Category::Empty)?("Key '"+core_->key_+"' not found."):"Not a scalar.");
+    << std::string("Key '" + core_->key_ + "' ") + 
+        ((core_->type_ == Value::Category::Empty)?(" not found."):" not a scalar.");
   return core_->scalar_.c_str();
 }
 

--- a/src/htm/regions/ClassifierRegion.cpp
+++ b/src/htm/regions/ClassifierRegion.cpp
@@ -205,7 +205,7 @@ void ClassifierRegion::setParameterBool(const std::string &name, Int64 index, bo
     RegionImpl::setParameterBool(name, index, val);
 }
 
-bool ClassifierRegion::getParameterBool(const std::string &name, Int64 index) {
+bool ClassifierRegion::getParameterBool(const std::string &name, Int64 index) const {
   if (name == "learn")
     return learn_;
   else  return RegionImpl::getParameterBool(name, index);

--- a/src/htm/regions/ClassifierRegion.hpp
+++ b/src/htm/regions/ClassifierRegion.hpp
@@ -54,7 +54,7 @@ public:
 
   static Spec *createSpec();
 
-  virtual bool getParameterBool(const std::string &name,   Int64 index = -1) override;
+  virtual bool getParameterBool(const std::string &name,   Int64 index = -1) const override;
   virtual void setParameterBool(const std::string &name, Int64 index, bool value) override;
 
   virtual void initialize() override;

--- a/src/htm/regions/DatabaseRegion.cpp
+++ b/src/htm/regions/DatabaseRegion.cpp
@@ -295,12 +295,13 @@ DatabaseRegion::executeCommand(const std::vector<std::string> &args,
 Spec *DatabaseRegion::createSpec() {
 
   auto ns = new Spec;
+  ns->name = "DatabaseRegion";
   ns->description =
       "DatabaseRegion is a node that writes multiple scalar streams "
       "to a SQLite3 database file (.db). The target filename is specified "
       "using the 'outputFile' parameter at run time. On each "
       "compute, all inputs are written "
-      "to the database.\n";
+      "to the database.";
 
   for (UInt i = 0; i< MAX_NUMBER_OF_INPUTS; i ++){ // create 10 inputs, user don't have to use them all
 		ns->inputs.add("dataIn"+std::to_string(i),
@@ -319,9 +320,9 @@ Spec *DatabaseRegion::createSpec() {
                             "This parameter must be set at runtime before "
                             "the first compute is called. Throws an "
                             "exception if it is not set or "
-                            "the file cannot be written to.\n",
-                            NTA_BasicType_Byte,
-                            0,  // elementCount
+                            "the file cannot be written to.",
+                            NTA_BasicType_Str,
+                            1,  // elementCount
                             "", // constraints
                             "", // defaultValue
                             ParameterSpec::ReadWriteAccess));

--- a/src/htm/regions/DatabaseRegion.cpp
+++ b/src/htm/regions/DatabaseRegion.cpp
@@ -262,7 +262,7 @@ void DatabaseRegion::setParameterString(const std::string &paramName,
 }
 
 std::string DatabaseRegion::getParameterString(const std::string &paramName,
-                                                   Int64 index) {
+                                                   Int64 index) const {
   if (paramName == "outputFile") {
     return filename_;
   } else {

--- a/src/htm/regions/DatabaseRegion.hpp
+++ b/src/htm/regions/DatabaseRegion.hpp
@@ -58,7 +58,7 @@ public:
   size_t getNodeOutputElementCount(const std::string &outputName) const override;
   void setParameterString(const std::string &name, Int64 index,
                           const std::string &s) override;
-  std::string getParameterString(const std::string &name, Int64 index) override;
+  std::string getParameterString(const std::string &name, Int64 index) const override;
 
   void initialize() override;
 

--- a/src/htm/regions/DateEncoderRegion.cpp
+++ b/src/htm/regions/DateEncoderRegion.cpp
@@ -180,12 +180,12 @@ void DateEncoderRegion::setParameterBool(const std::string &name, Int64 index, b
     RegionImpl::setParameterBool(name, index, value);
 }
 
-Int64 DateEncoderRegion::getParameterInt64(const std::string &name, Int64 index) {
+Int64 DateEncoderRegion::getParameterInt64(const std::string &name, Int64 index) const {
   if (name == "sensedTime") { return static_cast<Int64>(sensedTime_);}
   else return RegionImpl::getParameterInt64(name, index);
 }
 
-Real32 DateEncoderRegion::getParameterReal32(const std::string &name, Int64 index) {
+Real32 DateEncoderRegion::getParameterReal32(const std::string &name, Int64 index) const {
   if (name == "season_radius")
     return encoder_->parameters.season_radius;
   else if (name == "dayOfWeek_radius")
@@ -198,7 +198,7 @@ Real32 DateEncoderRegion::getParameterReal32(const std::string &name, Int64 inde
     return RegionImpl::getParameterReal32(name, index);
 }
 
-UInt32 DateEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 DateEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) const {
   if (name == "season_width")
     return encoder_->parameters.season_width;
   else if (name == "dayOfWeek_width")
@@ -217,12 +217,12 @@ UInt32 DateEncoderRegion::getParameterUInt32(const std::string &name, Int64 inde
     return RegionImpl::getParameterUInt32(name, index);
 }
 
-bool DateEncoderRegion::getParameterBool(const std::string &name, Int64 index) {
+bool DateEncoderRegion::getParameterBool(const std::string &name, Int64 index) const {
   if (name == "verbose") return encoder_->parameters.verbose;
   else  return RegionImpl::getParameterBool(name, index);
 }
 
-std::string DateEncoderRegion::getParameterString(const std::string& name, Int64 index) {
+std::string DateEncoderRegion::getParameterString(const std::string& name, Int64 index) const {
   if (name == "custom_days") {
     std::string buffer;
     for (size_t i = 0; i < encoder_->parameters.custom_days.size(); i++) {

--- a/src/htm/regions/DateEncoderRegion.hpp
+++ b/src/htm/regions/DateEncoderRegion.hpp
@@ -51,11 +51,11 @@ public:
 
   static Spec *createSpec();
 
-  virtual Int64 getParameterInt64(const std::string &name, Int64 index = -1) override;
-  virtual Real32 getParameterReal32(const std::string &name, Int64 index = -1) override;
-  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) override;
-  virtual bool getParameterBool(const std::string &name,   Int64 index = -1) override;
-  virtual std::string getParameterString(const std::string &name, Int64 index) override;
+  virtual Int64 getParameterInt64(const std::string &name, Int64 index = -1) const override;
+  virtual Real32 getParameterReal32(const std::string &name, Int64 index = -1) const override;
+  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) const override;
+  virtual bool getParameterBool(const std::string &name,   Int64 index = -1) const override;
+  virtual std::string getParameterString(const std::string &name, Int64 index) const override;
   virtual void setParameterReal32(const std::string &name, Int64 index, Real32 value) override;
   virtual void setParameterInt64(const std::string &name, Int64 index, Int64 value) override;
   virtual void setParameterBool(const std::string &name, Int64 index, bool value) override;

--- a/src/htm/regions/FileInputRegion.cpp
+++ b/src/htm/regions/FileInputRegion.cpp
@@ -318,6 +318,7 @@ size_t FileInputRegion::getNodeOutputElementCount(const std::string &outputName)
 
 Spec *FileInputRegion::createSpec() {
   auto ns = new Spec;
+  ns->name = "FileInputRegion";
   ns->description =
       "FileInputRegion is a basic sensor for reading files containing "
       "vectors.\n"

--- a/src/htm/regions/FileInputRegion.cpp
+++ b/src/htm/regions/FileInputRegion.cpp
@@ -529,7 +529,7 @@ Spec *FileInputRegion::createSpec() {
 
 
 //--------------------------------------------------------------------------------
-UInt32 FileInputRegion::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 FileInputRegion::getParameterUInt32(const std::string &name, Int64 index) const {
   if (name == "vectorCount") {
     return (UInt32)vectorFile_.vectorCount();
   } else if (name == "repeatCount") {
@@ -547,7 +547,7 @@ UInt32 FileInputRegion::getParameterUInt32(const std::string &name, Int64 index)
   }
 }
 
-Int32 FileInputRegion::getParameterInt32(const std::string &name, Int64 index) {
+Int32 FileInputRegion::getParameterInt32(const std::string &name, Int64 index) const {
   if (name == "position") {
     if (vectorFile_.vectorCount() == 0) return -1;
     return curVector_;
@@ -555,7 +555,7 @@ Int32 FileInputRegion::getParameterInt32(const std::string &name, Int64 index) {
     return RegionImpl::getParameterInt32(name, index);
   }
 }
-std::string FileInputRegion::getParameterString(const std::string &name, Int64 index) {
+std::string FileInputRegion::getParameterString(const std::string &name, Int64 index) const {
   if (name == "scalingMode") {
     return scalingMode_;
   } else if (name == "recentFile") {
@@ -566,8 +566,7 @@ std::string FileInputRegion::getParameterString(const std::string &name, Int64 i
 }
 
 
-void FileInputRegion::getParameterArray(const std::string &name, Int64 index,
-                                         Array &a) {
+void FileInputRegion::getParameterArray(const std::string &name, Int64 index, Array &a) const {
   if (a.getCount() != dataOut_.getCount())
     NTA_THROW << "getParameterArray(), array size is: " << a.getCount()
               << "instead of : " << dataOut_.getCount();
@@ -664,7 +663,7 @@ void FileInputRegion::setParameterArray(const std::string &name, Int64 index,
   scalingMode_ = "custom";
 }
 
-size_t FileInputRegion::getParameterArrayCount(const std::string &name, Int64 index) {
+size_t FileInputRegion::getParameterArrayCount(const std::string &name, Int64 index) const {
   NTA_CHECK (name == "scaleVector" || name == "offsetVector")
      << "FileInputRegion::getParameterArrayCount(), unknown array parameter: "<< name;
   return dataOut_.getCount();

--- a/src/htm/regions/FileInputRegion.hpp
+++ b/src/htm/regions/FileInputRegion.hpp
@@ -268,11 +268,11 @@ public:
   static Spec *createSpec();
   size_t getNodeOutputElementCount(const std::string &outputName) const override;
 
-  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) override;
-  virtual Int32 getParameterInt32(const std::string &name, Int64 index = -1) override;
-  virtual std::string getParameterString(const std::string &name, Int64 index = -1) override;
-  virtual void getParameterArray(const std::string &name, Int64 index, Array &array) override;
-  virtual size_t getParameterArrayCount(const std::string &name, Int64 index) override;
+  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) const override;
+  virtual Int32 getParameterInt32(const std::string &name, Int64 index = -1) const override;
+  virtual std::string getParameterString(const std::string &name, Int64 index = -1) const override;
+  virtual void getParameterArray(const std::string &name, Int64 index, Array &array) const override;
+  virtual size_t getParameterArrayCount(const std::string &name, Int64 index) const override;
 
   virtual void setParameterUInt32(const std::string &name, Int64 index, UInt32 value) override;
   virtual void setParameterInt32(const std::string &name, Int64 index, Int32 value) override;

--- a/src/htm/regions/FileOutputRegion.cpp
+++ b/src/htm/regions/FileOutputRegion.cpp
@@ -144,7 +144,7 @@ void FileOutputRegion::setParameterString(const std::string &paramName,
 }
 
 std::string FileOutputRegion::getParameterString(const std::string &paramName,
-                                                   Int64 index) {
+                                                   Int64 index) const {
   if (paramName == "outputFile") {
     return filename_;
   } else {

--- a/src/htm/regions/FileOutputRegion.cpp
+++ b/src/htm/regions/FileOutputRegion.cpp
@@ -185,6 +185,7 @@ FileOutputRegion::executeCommand(const std::vector<std::string> &args,
 Spec *FileOutputRegion::createSpec() {
 
   auto ns = new Spec;
+  ns->name = "FileOutputRegion";
   ns->description =
       "FileOutputRegion is a node that simply writes its "
       "input vectors to a text file. The target filename is specified "

--- a/src/htm/regions/FileOutputRegion.hpp
+++ b/src/htm/regions/FileOutputRegion.hpp
@@ -61,7 +61,7 @@ public:
   size_t getNodeOutputElementCount(const std::string &outputName) const override;
   void setParameterString(const std::string &name, Int64 index,
                           const std::string &s) override;
-  std::string getParameterString(const std::string &name, Int64 index) override;
+  std::string getParameterString(const std::string &name, Int64 index) const override;
 
   void initialize() override;
 

--- a/src/htm/regions/RDSEEncoderRegion.cpp
+++ b/src/htm/regions/RDSEEncoderRegion.cpp
@@ -140,12 +140,12 @@ void RDSEEncoderRegion::setParameterReal32(const std::string &name, Int64 index,
   else RegionImpl::setParameterReal32(name, index, value);
 }
 
-Real64 RDSEEncoderRegion::getParameterReal64(const std::string &name, Int64 index) {
+Real64 RDSEEncoderRegion::getParameterReal64(const std::string &name, Int64 index) const {
   if (name == "sensedValue") { return sensedValue_;}
   else return RegionImpl::getParameterReal64(name, index);
 }
 
-Real32 RDSEEncoderRegion::getParameterReal32(const std::string &name, Int64 index) {
+Real32 RDSEEncoderRegion::getParameterReal32(const std::string &name, Int64 index) const {
   if (name == "resolution")    return encoder_->parameters.resolution;
   else if (name == "noise")    return noise_;
   else if (name == "radius")   return encoder_->parameters.radius;
@@ -153,14 +153,14 @@ Real32 RDSEEncoderRegion::getParameterReal32(const std::string &name, Int64 inde
   else return RegionImpl::getParameterReal32(name, index);
 }
 
-UInt32 RDSEEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 RDSEEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) const {
   if (name == "size")            return encoder_->parameters.size;
   else if (name == "activeBits") return encoder_->parameters.activeBits;
   else if (name == "seed")       return encoder_->parameters.seed;
   else return RegionImpl::getParameterUInt32(name, index);
 }
 
-bool RDSEEncoderRegion::getParameterBool(const std::string &name, Int64 index) {
+bool RDSEEncoderRegion::getParameterBool(const std::string &name, Int64 index) const {
   if (name == "category") return encoder_->parameters.category;
   else  return RegionImpl::getParameterBool(name, index);
 }

--- a/src/htm/regions/RDSEEncoderRegion.hpp
+++ b/src/htm/regions/RDSEEncoderRegion.hpp
@@ -51,10 +51,10 @@ public:
 
   static Spec *createSpec();
 
-  virtual Real64 getParameterReal64(const std::string &name, Int64 index = -1) override;
-  virtual Real32 getParameterReal32(const std::string &name, Int64 index = -1) override;
-  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) override;
-  virtual bool getParameterBool(const std::string &name,   Int64 index = -1) override;
+  virtual Real64 getParameterReal64(const std::string &name, Int64 index = -1) const override;
+  virtual Real32 getParameterReal32(const std::string &name, Int64 index = -1) const override;
+  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) const override;
+  virtual bool getParameterBool(const std::string &name,   Int64 index = -1) const override;
   virtual void setParameterReal32(const std::string &name, Int64 index, Real32 value) override;
   virtual void setParameterReal64(const std::string &name, Int64 index, Real64 value) override;
   virtual void initialize() override;

--- a/src/htm/regions/SPRegion.cpp
+++ b/src/htm/regions/SPRegion.cpp
@@ -185,7 +185,7 @@ size_t SPRegion::getNodeOutputElementCount(const std::string &outputName) const 
 
 Spec *SPRegion::createSpec() {
   auto ns = new Spec;
-
+  ns->name = "SPRegion";
   ns->description =
       "SPRegion. This implements the Spatial Pooler algorithm as a plugin "
       "for the Network framework.  The Spatial Pooler manages relationships "

--- a/src/htm/regions/SPRegion.cpp
+++ b/src/htm/regions/SPRegion.cpp
@@ -571,7 +571,7 @@ Spec *SPRegion::createSpec() {
 //
 ////////////////////////////////////////////////////////////////////////
 
-UInt32 SPRegion::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 SPRegion::getParameterUInt32(const std::string &name, Int64 index) const {
   NTA_CHECK(name.size() > 0);
   switch (name[0]) {
   case 'a':
@@ -641,21 +641,21 @@ UInt32 SPRegion::getParameterUInt32(const std::string &name, Int64 index) {
   return this->RegionImpl::getParameterUInt32(name, index); // default
 }
 
-Int32 SPRegion::getParameterInt32(const std::string &name, Int64 index) {
+Int32 SPRegion::getParameterInt32(const std::string &name, Int64 index) const {
   if (name == "seed") {
     return args_.seed;
   }
   return this->RegionImpl::getParameterInt32(name, index); // default
 }
 
-UInt64 SPRegion::getParameterUInt64(const std::string &name, Int64 index) {
+UInt64 SPRegion::getParameterUInt64(const std::string &name, Int64 index) const {
   if (name == "computeCallback") {
     return (UInt64)computeCallback_;
   }
   return this->RegionImpl::getParameterUInt64(name, index); // default
 }
 
-Real32 SPRegion::getParameterReal32(const std::string &name, Int64 index) {
+Real32 SPRegion::getParameterReal32(const std::string &name, Int64 index) const {
   switch (name[0]) {
   case 'b':
     if (name == "boostStrength") {
@@ -713,7 +713,7 @@ Real32 SPRegion::getParameterReal32(const std::string &name, Int64 index) {
   return this->RegionImpl::getParameterReal32(name, index); // default
 }
 
-bool SPRegion::getParameterBool(const std::string &name, Int64 index) {
+bool SPRegion::getParameterBool(const std::string &name, Int64 index) const {
   if (name == "globalInhibition") {
     if (sp_)
       return sp_->getGlobalInhibition();
@@ -731,7 +731,7 @@ bool SPRegion::getParameterBool(const std::string &name, Int64 index) {
 
 // copy the contents of the requested array into the caller's array.
 // Allocate the buffer if one is not provided.  Convert data types if needed.
-void SPRegion::getParameterArray(const std::string &name, Int64 index, Array &array) {
+void SPRegion::getParameterArray(const std::string &name, Int64 index, Array &array) const {
   if (name == "spatialPoolerInput") {
     array = getInput("bottomUpIn")->getData().copy();
   } else if (name == "spatialPoolerOutput") {
@@ -746,7 +746,7 @@ void SPRegion::getParameterArray(const std::string &name, Int64 index, Array &ar
   }
 }
 
-size_t SPRegion::getParameterArrayCount(const std::string &name, Int64 index) {
+size_t SPRegion::getParameterArrayCount(const std::string &name, Int64 index) const {
   if (name == "spatialPoolerInput") {
     return getInput("bottomUpIn")->getData().getCount();
   } else if (name == "spatialPoolerOutput") {
@@ -761,7 +761,7 @@ size_t SPRegion::getParameterArrayCount(const std::string &name, Int64 index) {
   return 0;
 }
 
-std::string SPRegion::getParameterString(const std::string &name, Int64 index) {
+std::string SPRegion::getParameterString(const std::string &name, Int64 index) const {
   if (name == "spatialImp") {
     return spatialImp_;
   }

--- a/src/htm/regions/SPRegion.hpp
+++ b/src/htm/regions/SPRegion.hpp
@@ -139,14 +139,14 @@ class SPRegion  : public RegionImpl, Serializable
     size_t getNodeOutputElementCount(const std::string& outputName) const override;
 
 		/* -----------  Optional RegionImpl Interface methods ------- */
-    UInt32 getParameterUInt32(const std::string& name, Int64 index) override;
-    Int32 getParameterInt32(const std::string& name, Int64 index) override;
-    UInt64 getParameterUInt64(const std::string &name, Int64 index) override;
-    Real32 getParameterReal32(const std::string& name, Int64 index) override;
-    bool   getParameterBool(const std::string& name, Int64 index) override;
-    std::string getParameterString(const std::string& name, Int64 index) override;
-    void getParameterArray(const std::string& name, Int64 index, Array & array) override;
-    size_t getParameterArrayCount(const std::string &name, Int64 index) override;
+    UInt32 getParameterUInt32(const std::string& name, Int64 index) const override;
+    Int32 getParameterInt32(const std::string& name, Int64 index) const override;
+    UInt64 getParameterUInt64(const std::string &name, Int64 index) const override;
+    Real32 getParameterReal32(const std::string& name, Int64 index) const override;
+    bool   getParameterBool(const std::string& name, Int64 index) const override;
+    std::string getParameterString(const std::string& name, Int64 index) const override;
+    void getParameterArray(const std::string& name, Int64 index, Array & array) const override;
+    size_t getParameterArrayCount(const std::string &name, Int64 index) const override;
 
 
     void setParameterUInt32(const std::string& name, Int64 index, UInt32 value) override;

--- a/src/htm/regions/ScalarEncoderRegion.cpp
+++ b/src/htm/regions/ScalarEncoderRegion.cpp
@@ -234,7 +234,7 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
   return ns;
 }
 
-Real64 ScalarEncoderRegion::getParameterReal64(const std::string &name, Int64 index) {
+Real64 ScalarEncoderRegion::getParameterReal64(const std::string &name, Int64 index) const {
   if (name == "sensedValue") {
     return sensedValue_;
   } else if (name == "resolution") return encoder_->parameters.resolution;
@@ -249,7 +249,7 @@ Real64 ScalarEncoderRegion::getParameterReal64(const std::string &name, Int64 in
   }
 }
 
-bool ScalarEncoderRegion::getParameterBool(const std::string& name, Int64 index) {
+bool ScalarEncoderRegion::getParameterBool(const std::string& name, Int64 index) const {
   if (name == "periodic") 
     return encoder_->parameters.periodic;
   if (name == "clipInput")
@@ -259,7 +259,7 @@ bool ScalarEncoderRegion::getParameterBool(const std::string& name, Int64 index)
   }
 }
 
-UInt32 ScalarEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 ScalarEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) const {
   if (name == "n" || name == "size") {
     return (UInt32)encoder_->size;
   }

--- a/src/htm/regions/ScalarEncoderRegion.cpp
+++ b/src/htm/regions/ScalarEncoderRegion.cpp
@@ -120,7 +120,7 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
 
 /* static */ Spec *ScalarEncoderRegion::createSpec() {
   auto ns = new Spec;
-
+  ns->name = "ScalarEncoderRegion";
   ns->singleNodeOnly = true;
 
   /* ----- parameters ----- */
@@ -224,7 +224,7 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
                                         true  // isDefaultOutput
                                         ));
 
-  ns->outputs.add("bucket", OutputSpec("Quantized sensedValue for this iteration.  Becomres the title in ClassifierRegion.",
+  ns->outputs.add("bucket", OutputSpec("Quantized sensedValue for this iteration.  Becomes the title in ClassifierRegion.",
                                        NTA_BasicType_Real64,
                                        1,    // elementCount
                                        false, // isRegionLevel

--- a/src/htm/regions/ScalarEncoderRegion.hpp
+++ b/src/htm/regions/ScalarEncoderRegion.hpp
@@ -50,9 +50,9 @@ public:
 
   static Spec *createSpec();
 
-  virtual Real64 getParameterReal64(const std::string &name, Int64 index = -1) override;
-  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) override;
-  virtual bool getParameterBool(const std::string &name, Int64 index = -1) override;
+  virtual Real64 getParameterReal64(const std::string &name, Int64 index = -1) const override;
+  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) const override;
+  virtual bool getParameterBool(const std::string &name, Int64 index = -1) const override;
   virtual void setParameterReal64(const std::string &name, Int64 index, Real64 value) override;
   virtual void initialize() override;
 

--- a/src/htm/regions/TMRegion.cpp
+++ b/src/htm/regions/TMRegion.cpp
@@ -279,6 +279,7 @@ void TMRegion::compute() {
 Spec *TMRegion::createSpec() {
   auto ns = new Spec;
 
+  ns->name = "TMRegion";
   ns->description =
       "TMRegion. Class implementing the temporal memory algorithm as "
       "described in 'BAMI "

--- a/src/htm/regions/TMRegion.cpp
+++ b/src/htm/regions/TMRegion.cpp
@@ -607,7 +607,7 @@ Spec *TMRegion::createSpec() {
 //
 ////////////////////////////////////////////////////////////////////////
 
-UInt32 TMRegion::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 TMRegion::getParameterUInt32(const std::string &name, Int64 index) const {
 
     if (name == "activationThreshold") {
       if (tm_)
@@ -661,7 +661,7 @@ UInt32 TMRegion::getParameterUInt32(const std::string &name, Int64 index) {
 }
 
 
-Int32 TMRegion::getParameterInt32(const std::string &name, Int64 index) {
+Int32 TMRegion::getParameterInt32(const std::string &name, Int64 index) const {
   if (name == "activationThreshold") {
     if (tm_)
       return tm_->getActivationThreshold();
@@ -674,7 +674,7 @@ Int32 TMRegion::getParameterInt32(const std::string &name, Int64 index) {
 }
 
 
-Real32 TMRegion::getParameterReal32(const std::string &name, Int64 index) {
+Real32 TMRegion::getParameterReal32(const std::string &name, Int64 index) const {
 
     if (name == "anomaly") {
       if (tm_)
@@ -711,7 +711,7 @@ Real32 TMRegion::getParameterReal32(const std::string &name, Int64 index) {
 }
 
 
-bool TMRegion::getParameterBool(const std::string &name, Int64 index) {
+bool TMRegion::getParameterBool(const std::string &name, Int64 index) const {
   if (name == "checkInputs") {
     if (tm_) {
       return tm_->getCheckInputs();
@@ -728,7 +728,7 @@ bool TMRegion::getParameterBool(const std::string &name, Int64 index) {
 }
 
 
-std::string TMRegion::getParameterString(const std::string &name, Int64 index) {
+std::string TMRegion::getParameterString(const std::string &name, Int64 index) const {
   return this->RegionImpl::getParameterString(name, index);
 }
 

--- a/src/htm/regions/TMRegion.hpp
+++ b/src/htm/regions/TMRegion.hpp
@@ -136,11 +136,11 @@ public:
 
 
   /* -----------  Optional RegionImpl Interface methods ------- */
-  UInt32 getParameterUInt32(const std::string &name, Int64 index) override;
-  Int32 getParameterInt32(const std::string &name, Int64 index) override;
-  Real32 getParameterReal32(const std::string &name, Int64 index) override;
-  bool getParameterBool(const std::string &name, Int64 index) override;
-  std::string getParameterString(const std::string &name, Int64 index) override;
+  UInt32 getParameterUInt32(const std::string &name, Int64 index) const override;
+  Int32 getParameterInt32(const std::string &name, Int64 index) const override;
+  Real32 getParameterReal32(const std::string &name, Int64 index) const override;
+  bool getParameterBool(const std::string &name, Int64 index) const override;
+  std::string getParameterString(const std::string &name, Int64 index) const override;
 
   void setParameterUInt32(const std::string &name, Int64 index,UInt32 value) override;
   void setParameterInt32(const std::string &name, Int64 index,Int32 value) override;

--- a/src/htm/regions/TestNode.cpp
+++ b/src/htm/regions/TestNode.cpp
@@ -216,6 +216,7 @@ void TestNode::compute() {
 Spec *TestNode::createSpec() {
   auto ns = new Spec;
 
+  ns->name = "TestNode";
   ns->description = "TestNode. Used as a plain simple plugin Region for unit tests only. "
       "This is not useful for any real applicaton.";
 

--- a/src/htm/regions/TestNode.cpp
+++ b/src/htm/regions/TestNode.cpp
@@ -381,7 +381,7 @@ Spec *TestNode::createSpec() {
 
   return ns;
 }
-Int32 TestNode::getParameterInt32(const std::string &name, Int64 index) {
+Int32 TestNode::getParameterInt32(const std::string &name, Int64 index) const {
   if (name == "count") {
     return outputElementCount_;
   }
@@ -392,7 +392,7 @@ Int32 TestNode::getParameterInt32(const std::string &name, Int64 index) {
   }
 }
 
-UInt32 TestNode::getParameterUInt32(const std::string &name, Int64 index) {
+UInt32 TestNode::getParameterUInt32(const std::string &name, Int64 index) const {
   if (name == "uint32Param") {
     return uint32Param_;
   } else if (name == "unclonedParam") {
@@ -415,14 +415,14 @@ UInt32 TestNode::getParameterUInt32(const std::string &name, Int64 index) {
     return RegionImpl::getParameterUInt32(name, index);
   }
 }
-Int64 TestNode::getParameterInt64(const std::string &name, Int64 index) {
+Int64 TestNode::getParameterInt64(const std::string &name, Int64 index) const {
   if (name == "int64Param") {
     return int64Param_;
   } else {
     return RegionImpl::getParameterInt64(name, index);
   }
 }
-UInt64 TestNode::getParameterUInt64(const std::string &name, Int64 index) {
+UInt64 TestNode::getParameterUInt64(const std::string &name, Int64 index) const {
   if (name == "uint64Param") {
     return uint64Param_;
   } else if (name == "computeCallback") {
@@ -432,7 +432,7 @@ UInt64 TestNode::getParameterUInt64(const std::string &name, Int64 index) {
   }
 }
 
-Real32 TestNode::getParameterReal32(const std::string &name, Int64 index) {
+Real32 TestNode::getParameterReal32(const std::string &name, Int64 index) const {
   if (name == "real32Param") {
     return real32Param_;
   } else {
@@ -440,7 +440,7 @@ Real32 TestNode::getParameterReal32(const std::string &name, Int64 index) {
   }
 }
 
-Real64 TestNode::getParameterReal64(const std::string &name, Int64 index) {
+Real64 TestNode::getParameterReal64(const std::string &name, Int64 index) const {
   if (name == "real64Param") {
     return real64Param_;
   } else {
@@ -448,7 +448,7 @@ Real64 TestNode::getParameterReal64(const std::string &name, Int64 index) {
   }
 }
 
-bool TestNode::getParameterBool(const std::string &name, Int64 index) {
+bool TestNode::getParameterBool(const std::string &name, Int64 index) const {
   if (name == "boolParam") {
     return boolParam_;
   } else {
@@ -457,7 +457,7 @@ bool TestNode::getParameterBool(const std::string &name, Int64 index) {
 }
 
 
-std::string TestNode::getParameterString(const std::string &name, Int64 index) {
+std::string TestNode::getParameterString(const std::string &name, Int64 index) const {
   if (name == "stringParam") {
     return stringParam_;
   } else {
@@ -465,7 +465,7 @@ std::string TestNode::getParameterString(const std::string &name, Int64 index) {
   }
 }
 
-void TestNode::getParameterArray(const std::string &name, Int64 index, Array &array) {
+void TestNode::getParameterArray(const std::string &name, Int64 index, Array &array) const {
   if (name == "int64ArrayParam") {
   	Array a(NTA_BasicType_Int64, &int64ArrayParam_[0], int64ArrayParam_.size());
 	  array = a;
@@ -606,7 +606,7 @@ void TestNode::setParameterArray(const std::string &name, Int64 index, const Arr
 }
 
 
-size_t TestNode::getParameterArrayCount(const std::string &name, Int64 index) {
+size_t TestNode::getParameterArrayCount(const std::string &name, Int64 index) const {
   if (name == "int64ArrayParam") {
     return int64ArrayParam_.size();
   } else if (name == "real32ArrayParam") {

--- a/src/htm/regions/TestNode.hpp
+++ b/src/htm/regions/TestNode.hpp
@@ -137,17 +137,17 @@ public:
 
   /* -----------  Optional RegionImpl Interface methods ------- */
 
-  size_t getParameterArrayCount(const std::string &name, Int64 index) override;
+  size_t getParameterArrayCount(const std::string &name, Int64 index) const override;
 
-  virtual Int32 getParameterInt32(const std::string &name, Int64 index) override;
-  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index) override;
-  virtual Int64 getParameterInt64(const std::string &name, Int64 index) override;
-  virtual UInt64 getParameterUInt64(const std::string &name, Int64 index) override;
-  virtual Real32 getParameterReal32(const std::string &name, Int64 index) override;
-  virtual Real64 getParameterReal64(const std::string &name, Int64 index) override;
-  virtual bool getParameterBool(const std::string &name, Int64 index) override;
-  virtual std::string getParameterString(const std::string &name, Int64 index) override;
-  virtual void getParameterArray(const std::string &name, Int64 index, Array &array) override;
+  virtual Int32 getParameterInt32(const std::string &name, Int64 index) const override;
+  virtual UInt32 getParameterUInt32(const std::string &name, Int64 index) const override;
+  virtual Int64 getParameterInt64(const std::string &name, Int64 index) const override;
+  virtual UInt64 getParameterUInt64(const std::string &name, Int64 index) const override;
+  virtual Real32 getParameterReal32(const std::string &name, Int64 index) const override;
+  virtual Real64 getParameterReal64(const std::string &name, Int64 index) const override;
+  virtual bool getParameterBool(const std::string &name, Int64 index) const override;
+  virtual std::string getParameterString(const std::string &name, Int64 index) const override;
+  virtual void getParameterArray(const std::string &name, Int64 index, Array &array) const override;
 
   virtual void setParameterInt32(const std::string &name, Int64 index, Int32 value) override;
   virtual void setParameterUInt32(const std::string &name, Int64 index, UInt32 value) override;

--- a/src/htm/regions/VectorFile.cpp
+++ b/src/htm/regions/VectorFile.cpp
@@ -713,7 +713,7 @@ void VectorFile::getScaledVector(const UInt v, Real *out, UInt offset,
 }
 
 /// Get the scaling and offset values for element e
-void VectorFile::getScaling(const UInt e, Real &scale, Real &offset) {
+void VectorFile::getScaling(const UInt e, Real &scale, Real &offset) const {
   if (e >= getElementCount())
     NTA_THROW << "Requested non-existent element: " << e;
   scale = scaleVector_[e];

--- a/src/htm/regions/VectorFile.hpp
+++ b/src/htm/regions/VectorFile.hpp
@@ -88,7 +88,7 @@ public:
   void resetScaling(UInt nElements = 0);
 
   /// Get the scaling and offset values for element e
-  void getScaling(const UInt e, Real &scale, Real &offset);
+  void getScaling(const UInt e, Real &scale, Real &offset) const;
 
   /// Set the scale value for element e
   void setScale(const UInt e, const Real scale);

--- a/src/test/unit/regions/ClassifierRegionTest.cpp
+++ b/src/test/unit/regions/ClassifierRegionTest.cpp
@@ -244,4 +244,70 @@ TEST(ClassifierRegionTest, testSerialization) {
   Directory::removeTree("TestOutputDir", true);
 }
 
+TEST(ClassifierRegionTest, getSpecJSON) {
+  std::string expected = R"({"spec": "ClassifierRegion",
+  "parameters": {
+    "learn": {
+      "description": "if true, it performs the learn step",
+      "type": "Bool",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "true"
+    }
+  },
+  "inputs": {
+    "bucket": {
+      "description": "The quantized value of the current sample, one from each encoder if more than one, for the learn step",
+      "type": "Real64",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 0
+    },
+    "pattern": {
+      "description": "An SDR output bit pattern for a sample.  Usually the output of the SP or TM. For example: activeCells from TM",
+      "type": "SDR",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 0
+    },
+  },
+  "outputs": {
+    "pdf": {
+      "description": "probability distribution function (pdf) for each category or bucket. Sorted by title.  Warning, buffer length will grow.",
+      "type": "Real64",
+      "count": 0,
+      "regionLevel": 1,
+      "isDefaultOutput": 0
+    },
+    "predicted": {
+      "description": "An index (into pdf and titles) with the highest probability of being the match with the current pattern.",
+      "type": "UInt32",
+      "count": 1,
+      "regionLevel": 1,
+      "isDefaultOutput": 0
+    },
+    "titles": {
+      "description": "Quantized values of used samples which are the Titles corresponding to the pdf indexes. Sorted by title. Warning, buffer length will grow.",
+      "type": "Real64",
+      "count": 0,
+      "regionLevel": 1,
+      "isDefaultOutput": 0
+    },
+  }
+})";
+  Spec *spec = ClassifierRegion::createSpec();
+  std::string json = spec->toString();
+  EXPECT_STREQ(json.c_str(), expected.c_str());
+}
+
+TEST(ClassifierRegionTest, getParameters) {
+  std::string expected = "{\n  \"learn\": true,\n}";
+  Network net1;
+  std::shared_ptr<Region> region1 = net1.addRegion("classifier", "ClassifierRegion", "{\"learn\": true}");
+  std::string json = region1->getParameters();
+  EXPECT_STREQ(json.c_str(), expected.c_str());
+}
+
 } // namespace testing

--- a/src/test/unit/regions/DatabaseRegionTest.cpp
+++ b/src/test/unit/regions/DatabaseRegionTest.cpp
@@ -28,6 +28,7 @@
 #include <htm/engine/Network.hpp>
 #include <htm/utils/Log.hpp>
 #include <htm/ntypes/Value.hpp>
+#include <htm/regions/DatabaseRegion.hpp>
 
 namespace testing {
 
@@ -94,8 +95,126 @@ TEST(DatabaseRegionTest, overall)
 
 
 	 } catch (Exception &ex) {
-		 	FAIL() << "Catched exception : " << ex.getMessage();
+          // close database file
+          FAIL() << "Catched exception : " << ex.getMessage();
 	 }
 }
 
+
+TEST(DatabaseRegionTest, getSpecJSON) {
+  std::string expected = R"({"spec": "DatabaseRegion",
+  "description": "DatabaseRegion is a node that writes multiple scalar streams to a SQLite3 database file (.db). The target filename is specified using the 'outputFile' parameter at run time. On each compute, all inputs are written to the database.",
+  "parameters": {
+    "outputFile": {
+      "description": "Writes data stream to this database file on each compute. Database is recreated on initialization This parameter must be set at runtime before the first compute is called. Throws an exception if it is not set or the file cannot be written to.",
+      "type": "String",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": ""
+    }
+  },
+  "commands": {
+    "closeFile": "Close the current database file, if open.",
+    "getRowCount": "Gets sum of row counts for all tables in opened database.",
+    "commitTransaction": "Commits currently active transaction. Speeding up write avoiding repeat writes in loop.Transaction is started when databse is opened.",
+    },
+  "inputs": {
+    "dataIn0": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn1": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn2": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn3": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn4": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn5": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn6": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn7": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn8": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+    "dataIn9": {
+      "description": "Data scalar to be written to the database",
+      "type": "Real32",
+      "count": 0,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+  },
+  "outputs": {
+  }
+})";
+
+  Spec *spec = DatabaseRegion::createSpec();
+  std::string json = spec->toString();
+  EXPECT_STREQ(json.c_str(), expected.c_str());
+} // namespace testing
+
+TEST(DatabaseRegionTest, getParameters) {
+  std::string expected = "{\n  \"outputFile\": \":memory:\",\n}";
+  Network net1;
+  std::string output_file = ":memory:"; // in memory for this unit test. or could be physical file like: NapiOutputDir/Output.db
+  std::shared_ptr<Region> region1 = net1.addRegion("db", "DatabaseRegion", "{outputFile: '" + output_file + "'}");
+  std::string json = region1->getParameters();
+  EXPECT_STREQ(json.c_str(), expected.c_str());
+}
 } // testing namespace

--- a/src/test/unit/regions/DateEncoderRegionTest.cpp
+++ b/src/test/unit/regions/DateEncoderRegionTest.cpp
@@ -274,5 +274,162 @@ TEST(DateEncoderRegionTest, testSpecAndParameters)
     Directory::removeTree("TestOutputDir", true);
 	}
 
+  TEST(DateEncoderRegionTest, getSpecJSON) {
+          std::string expected = R"({"spec": "DateEncoderRegion",
+  "parameters": {
+    "custom_days": {
+      "description": "A list of day names to be included in the set, i.e. 'mon,tue,fri'",
+      "type": "String",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": ""
+    }
+    "custom_width": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "dayOfWeek_radius": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "1.0"
+    }
+    "dayOfWeek_width": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "holiday_dates": {
+      "description": "A list of holiday dates in format of 'month,day' or 'year,month,day', ie [[12,25],[2020,05,04]]",
+      "type": "String",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "[[12,25]]"
+    }
+    "holiday_width": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "noise": {
+      "description": "amount of noise to add to the output SDR. 0.01 is 1%",
+      "type": "Real32",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "0.0"
+    }
+    "season_radius": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "91.5"
+    }
+    "season_width": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "sensedTime": {
+      "description": "The value to encode. Unix EPOCH time. Overriden by input 'values'. A value of 0 means current time.",
+      "type": "Int64",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "0"
+    }
+    "size": {
+      "description": "Total width of encoded output.",
+      "type": "UInt32",
+      "count": 1,
+      "access": "ReadOnly",
+      "defaultValue": ""
+    }
+    "timeOfDay_radius": {
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "4.0"
+    }
+    "timeOfDay_width": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "verbose": {
+      "description": "if true, display debug info for each member encoded.",
+      "type": "Bool",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "false"
+    }
+    "weekend_width": {
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+  },
+  "inputs": {
+    "values": {
+      "description": "Values to encode. Overrides sensedTime.",
+      "type": "Int64",
+      "count": 1,
+      "required": 0,
+      "regionLevel": 1,
+      "isDefaultInput": 1
+    },
+  },
+  "outputs": {
+    "bucket": {
+      "description": "Quantized samples based on the radius. One sample for each attribute used. Becomes the title for this sample in Classifier.",
+      "type": "Real64",
+      "count": 0,
+      "regionLevel": 0,
+      "isDefaultOutput": 0
+    },
+    "encoded": {
+      "description": "Encoded bits. Not a true Sparse Data Representation.",
+      "type": "SDR",
+      "count": 0,
+      "regionLevel": 1,
+      "isDefaultOutput": 1
+    },
+  }
+})";
+    Spec *spec = DateEncoderRegion::createSpec();
+    std::string json = spec->toString();
+    EXPECT_STREQ(json.c_str(), expected.c_str());
+  }
+
+  TEST(DateEncoderRegionTest, getParameters) {
+    std::string expected = R"({
+  "custom_days": null,
+  "custom_width": 0,
+  "dayOfWeek_radius": 1.000000,
+  "dayOfWeek_width": 5,
+  "holiday_dates": "[[12,25]]",
+  "holiday_width": 0,
+  "noise": 0.000000,
+  "season_radius": 91.500000,
+  "season_width": 0,
+  "sensedTime": 0,
+  "size": 45,
+  "timeOfDay_radius": 4.000000,
+  "timeOfDay_width": 0,
+  "verbose": false,
+  "weekend_width": 5,
+})";
+    Network net1;
+    std::string params = "{\"dayOfWeek_width\": 5, \"weekend_width\": 5, \"verbose\": " + std::string((verbose) ? "true" : "false") + "}";
+    std::shared_ptr<Region> region1 = net1.addRegion("encoder", "DateEncoderRegion", params);
+    std::string json = region1->getParameters();
+    EXPECT_STREQ(json.c_str(), expected.c_str());
+  }
+
 
 } // namespace

--- a/src/test/unit/regions/ScalarEncoderRegionTest.cpp
+++ b/src/test/unit/regions/ScalarEncoderRegionTest.cpp
@@ -274,6 +274,142 @@ namespace testing
     // cleanup
     Directory::removeTree("TestOutputDir", true);
 	}
+  
+  
+  TEST(ScalarEncoderRegionTest, getSpecJSON) {
+     std::string expected = R"({"spec": "ScalarEncoderRegion",
+  "parameters": {
+    "sensedValue": {
+      "description": "Scalar input",
+      "type": "Real64",
+      "count": 1,
+      "access": "ReadWrite",
+      "defaultValue": "-1"
+    }
+    "size": {
+      "description": "The length of the encoding. Size of buffer",
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "n": {
+      "description": "Old name for the 'size' parameter.",
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "activeBits": {
+      "description": "The number of active bits in the encoding. i.e. how sparse",
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "w": {
+      "description": "Old name for the 'activeBits' parameter",
+      "type": "UInt32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "resolution": {
+      "description": "The resolution for the encoder",
+      "type": "Real64",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "radius": {
+      "description": "The radius for the encoder",
+      "type": "Real64",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "0"
+    }
+    "minValue": {
+      "description": "The minimum value for the input",
+      "type": "Real64",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "-1.0"
+    }
+    "maxValue": {
+      "description": "The maximum value for the input",
+      "type": "Real64",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "+1.0"
+    }
+    "periodic": {
+      "description": "Whether the encoder is periodic",
+      "type": "Bool",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "false"
+    }
+    "clipInput": {
+      "description": "Whether to clip inputs if they're outside [minValue, maxValue]",
+      "type": "Bool",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "false"
+    }
+  },
+  "inputs": {
+    "values": {
+      "description": "The input values to be encoded.",
+      "type": "Real64",
+      "count": 1,
+      "required": 0,
+      "regionLevel": 0,
+      "isDefaultInput": 1
+    },
+  },
+  "outputs": {
+    "encoded": {
+      "description": "Encoded value",
+      "type": "SDR",
+      "count": 0,
+      "regionLevel": 1,
+      "isDefaultOutput": 1
+    },
+    "bucket": {
+      "description": "Quantized sensedValue for this iteration.  Becomes the title in ClassifierRegion.",
+      "type": "Real64",
+      "count": 1,
+      "regionLevel": 0,
+      "isDefaultOutput": 0
+    },
+  }
+})";
+
+    Spec *spec = ScalarEncoderRegion::createSpec();
+    std::string json = spec->toString();
+    EXPECT_STREQ(json.c_str(), expected.c_str());
+  }
+
+  TEST(ScalarEncoderRegionTest, getParameters) {
+    std::string expected = R"({
+  "sensedValue": -1.000000,
+  "size": 100,
+  "n": 100,
+  "activeBits": 4,
+  "w": 4,
+  "resolution": 0.020833,
+  "radius": 0.083333,
+  "minValue": -1.000000,
+  "maxValue": 1.000000,
+  "periodic": false,
+  "clipInput": false,
+})";
+
+    Network net1;
+    std::shared_ptr<Region> region1 = net1.addRegion("region1", "ScalarEncoderRegion", "{n: 100, w: 4}");
+    std::string json = region1->getParameters();
+    EXPECT_STREQ(json.c_str(), expected.c_str());
+  }
 
 
 } // namespace


### PR DESCRIPTION
New function Network.getSpecJSON(region_type) will retrieve the spec for the specified region type.  The region does not have to be created first.

New function Region.getParameters() will retrieve all parameters on a region as a single JSON string.
New function Region.getParameterJSON( ) will retrieve the value of a specific parameter as a JSON string.

New unit test for python is in py/tests/networkapi/sinewave_test.py
  This is a python version of the simple sinewave example.

New C++ unit tests were added to some of the region implementation tests to confirm the above functions.

This is a specific request from @Zbysekz 