### PR TITLE
Timestamp real32 bug

### DIFF
--- a/src/htm/regions/FileInputRegion.cpp
+++ b/src/htm/regions/FileInputRegion.cpp
@@ -51,8 +51,8 @@ FileInputRegion::FileInputRegion(const ValueMap &params, Region *region)
     : RegionImpl(region),
 
       iterations_(0), curVector_(-1),
-      dataOut_(NTA_BasicType_Real64), categoryOut_(NTA_BasicType_Real64),
-      resetOut_(NTA_BasicType_Real64), filename_(""),
+      dataOut_(NTA_BasicType_Real64), categoryOut_(NTA_BasicType_Real32),
+      resetOut_(NTA_BasicType_Real32), filename_(""),
       recentFile_("") {
   repeatCount_ = params.getScalarT<UInt32>("repeatCount", 1);
   activeOutputCount_ = params.getScalarT<UInt32>("activeOutputCount", 0);
@@ -69,8 +69,8 @@ FileInputRegion::FileInputRegion(const ValueMap &params, Region *region)
 FileInputRegion::FileInputRegion(ArWrapper &wrapper, Region *region) 
     : RegionImpl(region), repeatCount_(1), iterations_(0), curVector_(-1),
       activeOutputCount_(0), hasCategoryOut_(false), hasResetOut_(false),
-      dataOut_(NTA_BasicType_Real64), categoryOut_(NTA_BasicType_Real64),
-      resetOut_(NTA_BasicType_Real64), filename_(""), scalingMode_("none"),
+      dataOut_(NTA_BasicType_Real64), categoryOut_(NTA_BasicType_Real32),
+      resetOut_(NTA_BasicType_Real32), filename_(""), scalingMode_("none"),
       recentFile_("") {
   cereal_adapter_load(wrapper);
 }
@@ -170,13 +170,13 @@ std::string FileInputRegion::executeCommand(const std::vector<std::string> &args
 {
   UInt32 argCount = (UInt32)args.size();
   // Get the first argument (command string)
-  NTA_CHECK(argCount > 0) << "VectorFileSensor: No command name";
+  NTA_CHECK(argCount > 0) << "FileInputRegion: No command name";
   string command = args[0];
 
   // Process each command
   if ((command == "loadFile") || (command == "appendFile")) {
     NTA_CHECK(argCount > 1)
-        << "VectorFileSensor: no filename specified for " << command;
+        << "FileInputRegion: no filename specified for " << command;
 
     UInt32 labeled = 2; // Default format is 2
 
@@ -366,7 +366,7 @@ Spec *FileInputRegion::createSpec() {
 
   ns->outputs.add( "categoryOut",
 				          OutputSpec("The current category encoded as a float (represent a whole number)",
-					                 NTA_BasicType_Real64,
+					                 NTA_BasicType_Real32,
 					                 1,    // count
 					                 false, // isRegionLevel
 					                 false // isDefaultOutput
@@ -375,7 +375,7 @@ Spec *FileInputRegion::createSpec() {
   ns->outputs.add("resetOut",
                   OutputSpec("Sequence reset signal: 0 - do nothing, otherwise "
                              "start a new sequence",
-                             NTA_BasicType_Real64,
+                             NTA_BasicType_Real32,
                              1,    // count
                              false, // isRegionLevel
                              false // isDefaultOutput
@@ -447,7 +447,7 @@ Spec *FileInputRegion::createSpec() {
 
   ns->parameters.add( "scaleVector",
 				   ParameterSpec("Set or return the current scale vector S.\n",
-				                 NTA_BasicType_Real64,
+				                 NTA_BasicType_Real32,
 				                 0,  // elementCount
 				                 "", // constraints
 				                 "", // defaultValue
@@ -455,7 +455,7 @@ Spec *FileInputRegion::createSpec() {
 
   ns->parameters.add( "offsetVector",
 			       ParameterSpec("Set or return the current offset vector 0.\n",
-			                     NTA_BasicType_Real64,
+			                     NTA_BasicType_Real32,
 			                     0,  // elementCount
 			                     "", // constraints
 			                     "", // defaultValue

--- a/src/htm/regions/FileInputRegion.cpp
+++ b/src/htm/regions/FileInputRegion.cpp
@@ -118,14 +118,14 @@ void FileInputRegion::compute() {
     curVector_ %= vectorFile_.vectorCount();
   }
 
-  Real *out = (Real *)dataOut_.getBuffer();
+  Real64 *out = (Real64 *)dataOut_.getBuffer();
 
   Size count = dataOut_.getCount();
   UInt offset = 0;
 
   if (hasCategoryOut_) {
     categoryOut_ = region_->getOutput("categoryOut")->getData();
-    Real *categoryOut = reinterpret_cast<Real *>(categoryOut_.getBuffer());
+    Real64 *categoryOut = reinterpret_cast<Real64 *>(categoryOut_.getBuffer());
     vectorFile_.getRawVector((htm::UInt)curVector_, categoryOut, offset, 1);
     offset++;
 
@@ -135,7 +135,7 @@ void FileInputRegion::compute() {
 
   if (hasResetOut_) {
     resetOut_ = region_->getOutput("resetOut")->getData();
-    Real *resetOut = reinterpret_cast<Real *>(resetOut_.getBuffer());
+    Real64 *resetOut = reinterpret_cast<Real64 *>(resetOut_.getBuffer());
     vectorFile_.getRawVector((htm::UInt)curVector_, resetOut, offset, 1);
     offset++;
 
@@ -571,10 +571,10 @@ void FileInputRegion::getParameterArray(const std::string &name, Int64 index, Ar
     NTA_THROW << "getParameterArray(), array size is: " << a.getCount()
               << "instead of : " << dataOut_.getCount();
 
-  Real *buf = (Real *)a.getBuffer();
-  Real dummy;
+  Real64 *buf = (Real64 *)a.getBuffer();
+  Real64 dummy;
   if (name == "scaleVector") {
-    Real *buf = (Real *)a.getBuffer();
+    Real64 *buf = (Real64 *)a.getBuffer();
     for (UInt i = 0; i < vectorFile_.getElementCount(); i++) {
       vectorFile_.getScaling(i, buf[i], dummy);
     }

--- a/src/htm/regions/FileInputRegion.cpp
+++ b/src/htm/regions/FileInputRegion.cpp
@@ -51,8 +51,8 @@ FileInputRegion::FileInputRegion(const ValueMap &params, Region *region)
     : RegionImpl(region),
 
       iterations_(0), curVector_(-1),
-      dataOut_(NTA_BasicType_Real32), categoryOut_(NTA_BasicType_Real32),
-      resetOut_(NTA_BasicType_Real32), filename_(""),
+      dataOut_(NTA_BasicType_Real64), categoryOut_(NTA_BasicType_Real64),
+      resetOut_(NTA_BasicType_Real64), filename_(""),
       recentFile_("") {
   repeatCount_ = params.getScalarT<UInt32>("repeatCount", 1);
   activeOutputCount_ = params.getScalarT<UInt32>("activeOutputCount", 0);
@@ -69,8 +69,8 @@ FileInputRegion::FileInputRegion(const ValueMap &params, Region *region)
 FileInputRegion::FileInputRegion(ArWrapper &wrapper, Region *region) 
     : RegionImpl(region), repeatCount_(1), iterations_(0), curVector_(-1),
       activeOutputCount_(0), hasCategoryOut_(false), hasResetOut_(false),
-      dataOut_(NTA_BasicType_Real32), categoryOut_(NTA_BasicType_Real32),
-      resetOut_(NTA_BasicType_Real32), filename_(""), scalingMode_("none"),
+      dataOut_(NTA_BasicType_Real64), categoryOut_(NTA_BasicType_Real64),
+      resetOut_(NTA_BasicType_Real64), filename_(""), scalingMode_("none"),
       recentFile_("") {
   cereal_adapter_load(wrapper);
 }
@@ -358,7 +358,7 @@ Spec *FileInputRegion::createSpec() {
       "more than N numbers on a line, the sensor retains only the first N.\n";
 
   ns->outputs.add("dataOut",
-                  OutputSpec("Data read from file", NTA_BasicType_Real32,
+                  OutputSpec("Data read from file", NTA_BasicType_Real64,
                              0,    // count
                              true, // isRegionLevel
                              true  // isDefaultOutput
@@ -366,7 +366,7 @@ Spec *FileInputRegion::createSpec() {
 
   ns->outputs.add( "categoryOut",
 				          OutputSpec("The current category encoded as a float (represent a whole number)",
-					                 NTA_BasicType_Real32,
+					                 NTA_BasicType_Real64,
 					                 1,    // count
 					                 false, // isRegionLevel
 					                 false // isDefaultOutput
@@ -375,7 +375,7 @@ Spec *FileInputRegion::createSpec() {
   ns->outputs.add("resetOut",
                   OutputSpec("Sequence reset signal: 0 - do nothing, otherwise "
                              "start a new sequence",
-                             NTA_BasicType_Real32,
+                             NTA_BasicType_Real64,
                              1,    // count
                              false, // isRegionLevel
                              false // isDefaultOutput
@@ -447,7 +447,7 @@ Spec *FileInputRegion::createSpec() {
 
   ns->parameters.add( "scaleVector",
 				   ParameterSpec("Set or return the current scale vector S.\n",
-				                 NTA_BasicType_Real32,
+				                 NTA_BasicType_Real64,
 				                 0,  // elementCount
 				                 "", // constraints
 				                 "", // defaultValue
@@ -455,7 +455,7 @@ Spec *FileInputRegion::createSpec() {
 
   ns->parameters.add( "offsetVector",
 			       ParameterSpec("Set or return the current offset vector 0.\n",
-			                     NTA_BasicType_Real32,
+			                     NTA_BasicType_Real64,
 			                     0,  // elementCount
 			                     "", // constraints
 			                     "", // defaultValue

--- a/src/htm/regions/FileOutputRegion.cpp
+++ b/src/htm/regions/FileOutputRegion.cpp
@@ -36,7 +36,7 @@
 namespace htm {
 
 FileOutputRegion::FileOutputRegion(const ValueMap &params, Region* region)
-    : RegionImpl(region), dataIn_(NTA_BasicType_Real32), filename_(""),
+    : RegionImpl(region), dataIn_(NTA_BasicType_Real64), filename_(""),
       outFile_(nullptr) {
   if (params.contains("outputFile")) {
     std::string s = params.getString("outputFile", "");
@@ -47,7 +47,7 @@ FileOutputRegion::FileOutputRegion(const ValueMap &params, Region* region)
 }
 
 FileOutputRegion::FileOutputRegion(ArWrapper& wrapper, Region* region)
-    : RegionImpl(region), dataIn_(NTA_BasicType_Real32), filename_(""),
+    : RegionImpl(region), dataIn_(NTA_BasicType_Real64), filename_(""),
       outFile_(nullptr) {
   cereal_adapter_load(wrapper);
 }
@@ -90,7 +90,7 @@ void FileOutputRegion::compute() {
   }
 
 
-  Real *inputVec = (Real *)(dataIn_.getBuffer());
+  Real64 *inputVec = (Real64 *)(dataIn_.getBuffer());
   NTA_CHECK(inputVec != nullptr);
   std::ofstream &outFile = *outFile_;
   for (Size offset = 0; offset < dataIn_.getCount(); ++offset) {
@@ -195,7 +195,7 @@ Spec *FileOutputRegion::createSpec() {
 
   ns->inputs.add("dataIn",
               InputSpec("Data to be written to file",
-                        NTA_BasicType_Real32,
+                        NTA_BasicType_Real64,
                         0,     // count
                         false, // required?
                         true, // isRegionLevel

--- a/src/htm/regions/VectorFile.cpp
+++ b/src/htm/regions/VectorFile.cpp
@@ -164,7 +164,7 @@ void VectorFile::loadVectors(std::istream& inFile,
       inFile >> vectorLabel;
     }
 
-    auto b = new Real[elementCount];
+    auto b = new Real64[elementCount];
     for (Size i = 0; i < elementCount; ++i) {
       inFile >> b[i];
     }
@@ -215,7 +215,7 @@ void VectorFile::saveVectors(ostream &out, Size nColumns, UInt32 fileFormat,
     end = begin;
 
   // Setup iterators for the rows.
-  vector<Real *>::const_iterator i = (fileVectors_.begin() + size_t(begin));
+  vector<Real64 *>::const_iterator i = (fileVectors_.begin() + size_t(begin));
   auto iend = i + size_t(end - begin);
 
   switch (fileFormat) {
@@ -294,9 +294,9 @@ void VectorFile::saveVectors(ostream &out, Size nColumns, UInt32 fileFormat,
         if (nColumns)
           out << sep;
       }
-      const Real *p = *i;
+      const Real64 *p = *i;
       if (nColumns) {
-        const Real *pEnd = p + nColumns;
+        const Real64 *pEnd = p + nColumns;
         out << *(p++);
         for (; p < pEnd;)
           out << sep << *(p++);
@@ -310,11 +310,12 @@ void VectorFile::saveVectors(ostream &out, Size nColumns, UInt32 fileFormat,
   case 5: {
     if (end <= begin)
       return;
-    const Size rowBytes = nColumns * sizeof(Real32);
-    const bool needConversion = (sizeof(Real32) == sizeof(Real));
+    const Size rowBytes = nColumns * sizeof(Real64);
+    //const bool needConversion = (sizeof(Real64) == sizeof(Real));//always false
 
-    if (needConversion) {
-      auto buffer = new Real32[nColumns];
+    if (false) {//was needConversion - now it uses Real64 everywhere, so no need to convert
+    	;
+      /*auto buffer = new Real32[nColumns];
       try {
         for (; i != iend; ++i) {
           if (needConversion) {
@@ -328,7 +329,7 @@ void VectorFile::saveVectors(ostream &out, Size nColumns, UInt32 fileFormat,
         delete[] buffer;
         throw;
       }
-      delete[] buffer;
+      delete[] buffer;*/
     } else {
       for (; i != iend; ++i)
         out.write((char *)(*i), streamsize(rowBytes));
@@ -674,7 +675,7 @@ size_t VectorFile::getElementCount() const { return scaleVector_.size(); }
 
 /// Retrieve the i'th vector and copy into output without scaling
 /// output must have size at least elementCount
-void VectorFile::getRawVector(const UInt v, Real *out, UInt offset,
+void VectorFile::getRawVector(const UInt v, Real64 *out, UInt offset,
                               Size count) {
   if (v >= vectorCount())
     NTA_THROW << "Requested non-existent vector: " << v;
@@ -687,14 +688,14 @@ void VectorFile::getRawVector(const UInt v, Real *out, UInt offset,
               << " = " << offset + count
               << ", must be smaller than element count: " << getElementCount();
   // Get the pointers and copy over the vector
-  Real *vec = fileVectors_[v];
+  Real64 *vec = fileVectors_[v];
   for (Size i = 0; i < count; i++)
     out[i] = vec[offset + i];
 }
 
 /// Retrieve i'th vector, apply scaling and copy result into output
 /// output must have size at least 'count' elements
-void VectorFile::getScaledVector(const UInt v, Real *out, UInt offset,
+void VectorFile::getScaledVector(const UInt v, Real64 *out, UInt offset,
                                  Size count) {
   // Check if we have scaling. If not, use getRawVector().
   if (scaleVector_.size() == 0)
@@ -706,14 +707,14 @@ void VectorFile::getScaledVector(const UInt v, Real *out, UInt offset,
   NTA_CHECK(getElementCount() <= offset + count);
 
   // Get the pointers and copy over the vector
-  Real *vec = fileVectors_[v];
+  Real64 *vec = fileVectors_[v];
   for (Size i = 0; i < count; i++) {
     out[i] = scaleVector_[i] * (vec[i + offset] + offsetVector_[i]);
   }
 }
 
 /// Get the scaling and offset values for element e
-void VectorFile::getScaling(const UInt e, Real &scale, Real &offset) const {
+void VectorFile::getScaling(const UInt e, Real64 &scale, Real64 &offset) const {
   if (e >= getElementCount())
     NTA_THROW << "Requested non-existent element: " << e;
   scale = scaleVector_[e];
@@ -721,14 +722,14 @@ void VectorFile::getScaling(const UInt e, Real &scale, Real &offset) const {
 }
 
 /// Set the scale value for element e
-void VectorFile::setScale(const UInt e, const Real scale) {
+void VectorFile::setScale(const UInt e, const Real64 scale) {
   if (e >= getElementCount())
     NTA_THROW << "Requested non-existent element: " << e;
   scaleVector_[e] = scale;
 }
 
 /// Set the offset value for element e
-void VectorFile::setOffset(const UInt e, const Real offset) {
+void VectorFile::setOffset(const UInt e, const Real64 offset) {
   if (e >= getElementCount())
     NTA_THROW << "Requested non-existent element: " << e;
   offsetVector_[e] = offset;
@@ -750,7 +751,7 @@ void VectorFile::setStandardScaling() {
     for (Size i = 0; i < nv; i++)
       sum += fileVectors_[i][e];
     double mean = sum / nv;
-    offsetVector_[e] = (Real)(-mean);
+    offsetVector_[e] = (Real64)(-mean);
 
     // Now compute the squared term for stdev
     for (Size i = 0; i < nv; i++) {
@@ -763,7 +764,7 @@ void VectorFile::setStandardScaling() {
     if (fabs(stdev) < 0.00000001)
       NTA_THROW << "Error setting standard form, stdeviation is almost zero "
                    "for some component.";
-    scaleVector_[e] = (Real)(1.0 / stdev);
+    scaleVector_[e] = (Real64)(1.0 / stdev);
   }
 }
 

--- a/src/htm/regions/VectorFile.hpp
+++ b/src/htm/regions/VectorFile.hpp
@@ -91,10 +91,10 @@ public:
   void getScaling(const UInt e, Real64 &scale, Real64 &offset) const;
 
   /// Set the scale value for element e
-  void setScale(const UInt e, const Real scale);
+  void setScale(const UInt e, const Real64 scale);
 
   /// Set the offset value for element e
-  void setOffset(const UInt e, const Real offset);
+  void setOffset(const UInt e, const Real64 offset);
 
   /// Clear the set of vectors and labels, including scale and offset vectors,
   /// release all memory, and set numElements back to zero.

--- a/src/htm/regions/VectorFile.hpp
+++ b/src/htm/regions/VectorFile.hpp
@@ -65,11 +65,11 @@ public:
 
   /// Retrieve i'th vector, apply scaling and copy result into output
   /// output must have size of at least 'count' elements
-  void getScaledVector(const UInt i, Real *out, UInt offset, Size count);
+  void getScaledVector(const UInt i, Real64 *out, UInt offset, Size count);
 
   /// Retrieve the i'th vector and copy into output without scaling
   /// output must have size at least 'count' elements
-  void getRawVector(const UInt i, Real *out, UInt offset, Size count);
+  void getRawVector(const UInt i, Real64 *out, UInt offset, Size count);
 
   /// Return the number of stored vectors
   size_t vectorCount() const { return fileVectors_.size(); }
@@ -88,7 +88,7 @@ public:
   void resetScaling(UInt nElements = 0);
 
   /// Get the scaling and offset values for element e
-  void getScaling(const UInt e, Real &scale, Real &offset) const;
+  void getScaling(const UInt e, Real64 &scale, Real64 &offset) const;
 
   /// Set the scale value for element e
   void setScale(const UInt e, const Real scale);
@@ -146,10 +146,10 @@ public:
 	
 
 private:
-  std::vector<Real *> fileVectors_; // list of vectors
+  std::vector<Real64 *> fileVectors_; // list of vectors
   std::vector<bool> own_;           // memory ownership flags
-  std::vector<Real> scaleVector_;   // the scaling vector
-  std::vector<Real> offsetVector_;  // the offset vector
+  std::vector<Real64> scaleVector_;   // the scaling vector
+  std::vector<Real64> offsetVector_;  // the offset vector
 
   std::vector<std::string> elementLabels_; // string denoting the meaning of each element
   std::vector<std::string> vectorLabels_; // a string label for each vector
@@ -158,7 +158,7 @@ private:
   void appendCSVFile(std::istream &inFile, Size expectedElementCount);
 
   /// Read vectors from a binary file.
-  void appendFloat32File(const std::string &filename, Size expectedElements);
+  void appendFloat64File(const std::string &filename, Size expectedElements);
 
   /// Read vectors from a binary IDX file.
   void appendIDXFile(const std::string &filename, int expectedElements);

--- a/src/test/unit/engine/HelloRegionTest.cpp
+++ b/src/test/unit/engine/HelloRegionTest.cpp
@@ -41,7 +41,7 @@ TEST(HelloRegionTest, demo) {
   std::string path = Path::join("TestOutputDir", "Data.csv");
 
   // enter some arbitrary test data.
-  std::vector<std::vector<Real32>> testdata = {{0, 1.5f, 2.5f},
+  std::vector<std::vector<Real64>> testdata = {{0, 1.5f, 2.5f},
                                                {1, 1.5f, 2.5f},
                                                {2, 1.5f, 2.5f},
                                                {3, 1.5f, 2.5f}};
@@ -84,9 +84,9 @@ TEST(HelloRegionTest, demo) {
 
   // Get output
   const Array& outputArray = region->getOutputData("dataOut");
-  EXPECT_TRUE(outputArray.getType() == NTA_BasicType_Real32);
+  EXPECT_TRUE(outputArray.getType() == NTA_BasicType_Real64);
   EXPECT_EQ(outputArray.getCount(), testdata[0].size());
-  const Real32 *buffer = (const Real32 *)outputArray.getBuffer();
+  const Real64 *buffer = (const Real64 *)outputArray.getBuffer();
   for (size_t i = 0; i < outputArray.getCount(); i++)
     EXPECT_FLOAT_EQ(buffer[i], testdata[0][i]);
   // At this point we have consumed the first buffer from FileInputRegion.
@@ -116,7 +116,7 @@ TEST(HelloRegionTest, demo) {
   if (verbose) std::cout << "outputArray =" << outputArray << std::endl;
   if (verbose) std::cout << "outputArray2=" << outputArray2 << std::endl;
 
-  const Real32 *buffer2 = (const Real32 *)outputArray2.getBuffer();
+  const Real64 *buffer2 = (const Real64 *)outputArray2.getBuffer();
   EXPECT_EQ(data_cols, outputArray.getCount());
   ASSERT_EQ(outputArray2.getCount(), outputArray.getCount());
   for (size_t i = 0; i < outputArray2.getCount(); i++) {

--- a/src/test/unit/regions/DateEncoderRegionTest.cpp
+++ b/src/test/unit/regions/DateEncoderRegionTest.cpp
@@ -190,7 +190,7 @@ TEST(DateEncoderRegionTest, testSpecAndParameters)
 	  VERBOSE << "Checking data after first iteration..." << std::endl;
     Array r1OutputArray = reader->getOutputData("dataOut");
     VERBOSE << "  FileInputRegion Output" << r1OutputArray << std::endl;
-    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32)
+    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real64)
             << "actual type is " << BasicType::getName(r1OutputArray.getType());
     VERBOSE << "  " << std::endl;
 

--- a/src/test/unit/regions/RDSEEncoderRegionTest.cpp
+++ b/src/test/unit/regions/RDSEEncoderRegionTest.cpp
@@ -194,7 +194,7 @@ namespace testing
 	  VERBOSE << "Checking data after first iteration..." << std::endl;
     Array r1OutputArray = region1->getOutputData("dataOut");
     VERBOSE << "  FileInputRegion Output" << r1OutputArray << std::endl;
-    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32)
+    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real64)
             << "actual type is " << BasicType::getName(r1OutputArray.getType());
     VERBOSE << "  " << std::endl;
 
@@ -214,7 +214,7 @@ namespace testing
 
     VERBOSE << "  FileOutputRegion input" << std::endl;
     Array r4InputArray = region4->getInputData("dataIn");
-    ASSERT_TRUE(r4InputArray.getType() == NTA_BasicType_Real32)
+    ASSERT_TRUE(r4InputArray.getType() == NTA_BasicType_Real64)
       << "actual type is " << BasicType::getName(r4InputArray.getType());
 
     // cleanup

--- a/src/test/unit/regions/SPRegionTest.cpp
+++ b/src/test/unit/regions/SPRegionTest.cpp
@@ -225,10 +225,10 @@ namespace testing
     VERBOSE << "  FileInputRegion Output" << std::endl;
     Array r1OutputArray = region1->getOutputData("dataOut");
     EXPECT_EQ(r1OutputArray.getCount(), dataWidth);
-    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32)
+    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real64)
             << "actual type is " << BasicType::getName(r1OutputArray.getType());
 
-    Real32 *buffer1 = (Real32*) r1OutputArray.getBuffer();
+    Real64 *buffer1 = (Real64*) r1OutputArray.getBuffer();
 	  //for (size_t i = 0; i < r1OutputArray.getCount(); i++)
 	  //{
 		//VERBOSE << "  [" << i << "]=    " << buffer1[i] << "" << std::endl;
@@ -276,10 +276,10 @@ namespace testing
 
     VERBOSE << "  FileOutputRegion input" << std::endl;
     Array r3InputArray = region3->getInputData("dataIn");
-    ASSERT_TRUE(r3InputArray.getType() == NTA_BasicType_Real32)
+    ASSERT_TRUE(r3InputArray.getType() == NTA_BasicType_Real64)
       << "actual type is " << BasicType::getName(r3InputArray.getType());
     ASSERT_TRUE(r3InputArray.getCount() == columnCount);
-    const Real32 *buffer4 = (const Real32*)r3InputArray.getBuffer();
+    const Real64 *buffer4 = (const Real64*)r3InputArray.getBuffer();
     for (size_t i = 0; i < r3InputArray.getCount(); i++)
     {
       //VERBOSE << "  [" << i << "]=    " << buffer4[i] << "" << std::endl;

--- a/src/test/unit/regions/ScalarEncoderRegionTest.cpp
+++ b/src/test/unit/regions/ScalarEncoderRegionTest.cpp
@@ -193,7 +193,7 @@ namespace testing
 	  VERBOSE << "Checking data after first iteration..." << std::endl;
     Array r1OutputArray = region1->getOutputData("dataOut");
     VERBOSE << "  FileInputRegion Output" << r1OutputArray << std::endl;
-    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32)
+    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real64)
             << "actual type is " << BasicType::getName(r1OutputArray.getType());
     VERBOSE << "  " << std::endl;
 
@@ -213,7 +213,7 @@ namespace testing
 
     VERBOSE << "  FileOutputRegion input" << std::endl;
     Array r4InputArray = region4->getInputData("dataIn");
-    ASSERT_TRUE(r4InputArray.getType() == NTA_BasicType_Real32)
+    ASSERT_TRUE(r4InputArray.getType() == NTA_BasicType_Real64)
       << "actual type is " << BasicType::getName(r4InputArray.getType());
 
     // cleanup

--- a/src/test/unit/regions/TMRegionTest.cpp
+++ b/src/test/unit/regions/TMRegionTest.cpp
@@ -257,7 +257,7 @@ TEST(TMRegionTest, testLinking) {
   Array r1OutputArray = region1->getOutputData("dataOut");
   VERBOSE << "    " << r1OutputArray << "\n";
   EXPECT_EQ(r1OutputArray.getCount(), dataWidth);
-  EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32);
+  EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real64);
 
   // check anomaly
   EXPECT_FLOAT_EQ(region3->getParameterReal32("anomaly"), 1.0f);
@@ -323,7 +323,7 @@ TEST(TMRegionTest, testLinking) {
   VERBOSE << "   Input to FileOutputRegion "
           << region4->getInputDimensions("dataIn") << "\n";
   Array r4InputArray = region4->getInputData("dataIn");
-  EXPECT_EQ(r4InputArray.getType(), NTA_BasicType_Real32);
+  EXPECT_EQ(r4InputArray.getType(), NTA_BasicType_Real64);
   VERBOSE << "   " << r4InputArray << "\n";
   EXPECT_EQ(r4InputArray, expected3outa) << r4InputArray;
 

--- a/src/test/unit/regions/VectorFileTest.cpp
+++ b/src/test/unit/regions/VectorFileTest.cpp
@@ -135,7 +135,7 @@ namespace testing
     EXPECT_EQ(region1->getParameterInt32("position"), 0);
     Array a = region1->getOutputData("dataOut");
     VERBOSE << "1st vector=" << a << std::endl;
-    Array expected1(std::vector<Real32>({ 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }));
+    Array expected1(std::vector<Real64>({ 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }));
     EXPECT_TRUE(a == expected1);
 
 
@@ -144,7 +144,7 @@ namespace testing
     EXPECT_EQ(region1->getParameterInt32("position"), 5);
     a = region1->getOutputData("dataOut");
     VERBOSE << "5th vector=" << a << std::endl;
-    Array expected5(std::vector<Real32>({ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }));
+    Array expected5(std::vector<Real64>({ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }));
     EXPECT_TRUE(a == expected5);
 
     // cleanup
@@ -192,11 +192,11 @@ namespace testing
     VERBOSE << "  FileInputRegion Output" << std::endl;
     Array r1OutputArray = region1->getOutputData("dataOut");
     EXPECT_EQ(r1OutputArray.getCount(), dataWidth);
-    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32)
+    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real64)
             << "actual type is " << BasicType::getName(r1OutputArray.getType());
 
     Array r3InputArray = region3->getInputData("dataIn");
-    ASSERT_TRUE(r3InputArray.getType() == NTA_BasicType_Real32)
+    ASSERT_TRUE(r3InputArray.getType() == NTA_BasicType_Real64)
       << "actual type is " << BasicType::getName(r3InputArray.getType());
     ASSERT_TRUE(r3InputArray.getCount() == dataWidth);
 


### PR DESCRIPTION
Closes #869

Replaced Real32 and Real (this is global defined variable, can be Real32/Real64)  to Real64.

Now the datetimeEncoder test passes even in New York timezone (UTC-4).