### PR TITLE
Missing includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ git clone https://github.com/htm-community/htm.core
 
 - same as for Binary releases, plus:
 - **C++ compiler**: c++11/17 compatible (ie. g++, clang++).
+- boost library (if not a C++17 compiler that supports filesystem.)
+
+Note: Windows MSVC 2019 runs as C++17 by default.  On linux use -std=c++17 compile option to 
+      avoid needing boost.
 
 
 #### Simple Python build (any platform)
@@ -107,7 +111,7 @@ git clone https://github.com/htm-community/htm.core
    * If you are using Anaconda Python you must run within the `Anaconda Prompt` on Windows. Do not use --user or --force options.
 
    * If you run into problems due to caching of arguments in CMake, delete the
-   folder `<path-to-repo>/build` and try again.  This may only an issue when
+   folder `<path-to-repo>/build` and try again.  This may be only an issue when
    developing C++ code.
 
 3) After that completes you are ready to import the library:
@@ -155,8 +159,32 @@ make -j8 install
 
  * This will not build the Python interface. Use the Python build described above to build and install the python interface.
 
-Here is an example of a **debug build** of your own C++ app and link to htm.core as a shared library.
+Here is an example of a **Release build** of your own C++ app that links to htm.core as a shared library.
 ```
+#! /bin/sh
+# Using GCC on linux ...
+# First build htm.core from sources.
+#      cd <path-to-repo>
+#      mkdir -p build/scripts
+#      cd build/scripts
+#      cmake ../..
+#      make -j4 install
+#
+# Now build myapp
+# We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# The -I gives the path to the includes needed to use with the htm.core library.
+# The -L gives the path to the shared htm.core library location at build time.
+# The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
+g++ -o myapp -std=c++17  -I <path-to-repo>/build/Release/include myapp.cpp -L <path-to-repo>/build/Release/lib -lhtm_core -lpthread -ldl
+
+# Run myapp 
+export LD_LIBRARY_PATH=<path-to-repo>/build/Release/lib:$LD_LIBRARY_PATH
+./myapp
+```
+
+Here is an example of a **Debug build** of your own C++ app that links to htm.core as a shared library.
+```
+#! /bin/sh
 # Using GCC on linux ...
 # First build htm.core as debug from sources.
 #      cd <path-to-repo>
@@ -164,17 +192,18 @@ Here is an example of a **debug build** of your own C++ app and link to htm.core
 #      cd build/scripts
 #      cmake ../.. -DCMAKE_BUILD_TYPE=Debug
 #      make -j4 install
+#
+# Now build myapp
+# The -g -Og tells the compiler to build debug mode with no optimize.
 # We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
-# The -I gives the path to the includes needed to use the htm.core library.
+# The -I gives the path to the includes needed to use with the htm.core library.
 # The -L gives the path to the shared htm.core library location at build time.
 # The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
+g++ -g -Og -o myapp -std=c++17  -I <path-to-repo>/build/Debug/include myapp.cpp -L <path-to-repo>/build/Debug/lib -lhtm_core -lpthread -ldl
 
-# Now build your app
-g++ -g -o myapp -std=c++17  -I <path-to-repo>/build/Debug/include myapp.cpp -L <path-to-repo>/build/Debug/lib -lhtm_core -lpthread -ldl
-
-# Run your app
+# Run myapp in the debugger
 export LD_LIBRARY_PATH=<path-to-repo>/build/Debug/lib:$LD_LIBRARY_PATH
-./myapp
+gdb ./myapp
 ```
 
 ### Docker Builds

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ git clone https://github.com/htm-community/htm.core
 
 2) Run: `python setup.py install --user --force`
 
-   This will build and install everything.  The `--user` option prevents the system installed site-packages folder from being changed and avoids the need for admin privileges.  The `--force` option forces the package to be replaced if it already exists from a previous build. Alternatively you can type `pip uninstall htm.core` to remove a previous package before performing a build.
+   This will build and install a release version of htm.core.  The `--user` option prevents the system installed site-packages folder from being changed and avoids the need for admin privileges.  The `--force` option forces the package to be replaced if it already exists from a previous build. Alternatively you can type `pip uninstall htm.core` to remove a previous package before performing a build.
    
    * If you are using `virtualenv` you do not need the --user or --force options.
    * If you are using Anaconda Python you must run within the `Anaconda Prompt` on Windows. Do not use --user or --force options.
 
    * If you run into problems due to caching of arguments in CMake, delete the
-   folder `Repository/build` and try again.  This is only an issue when
+   folder `<path-to-repo>/build` and try again.  This may only an issue when
    developing C++ code.
 
 3) After that completes you are ready to import the library:
@@ -148,13 +148,34 @@ make -j8 install
 | REST Client Example    | `build/Release/bin/rest_client`      |
 
  * A debug library can be created by adding `-DCMAKE_BUILD_TYPE=Debug` to the cmake command above.
-   + The debug library will be put in `build/Debug`.
+   + The debug library will be put in `build/Debug` rather than `build/Release`.
      Use the cmake option `-DCMAKE_INSTALL_PREFIX=../Release` to change this.
 
  * The -j option can be used with the `make install` command to compile with multiple threads.
 
  * This will not build the Python interface. Use the Python build described above to build and install the python interface.
 
+Here is an example of a **debug build** of your own C++ app and link to htm.core as a shared library.
+```
+# Using GCC on linux ...
+# First build htm.core as debug from sources.
+#      cd <path-to-repo>
+#      mkdir -p build/scripts
+#      cd build/scripts
+#      cmake ../.. -DCMAKE_BUILD_TYPE=Debug
+#      make -j4 install
+# We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# The -I gives the path to the includes needed to use the htm.core library.
+# The -L gives the path to the shared htm.core library location at build time.
+# The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
+
+# Now build your app
+g++ -g -o myapp -std=c++17  -I <path-to-repo>/build/Debug/include myapp.cpp -L <path-to-repo>/build/Debug/lib -lhtm_core -lpthread -ldl
+
+# Run your app
+export LD_LIBRARY_PATH=<path-to-repo>/build/Debug/lib:$LD_LIBRARY_PATH
+./myapp
+```
 
 ### Docker Builds
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Here is an example of a **Release build** of your own C++ app that links to htm.
 # The -I gives the path to the includes needed to use with the htm.core library.
 # The -L gives the path to the shared htm.core library location at build time.
 # The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
-g++ -o myapp -std=c++17  -I <path-to-repo>/build/Release/include myapp.cpp -L <path-to-repo>/build/Release/lib -lhtm_core -lpthread -ldl
+g++ -o myapp -std=c++17 -I <path-to-repo>/build/Release/include myapp.cpp -L <path-to-repo>/build/Release/lib -lhtm_core -lpthread -ldl
 
 # Run myapp 
 export LD_LIBRARY_PATH=<path-to-repo>/build/Release/lib:$LD_LIBRARY_PATH
@@ -196,10 +196,11 @@ Here is an example of a **Debug build** of your own C++ app that links to htm.co
 # Now build myapp
 # The -g -Og tells the compiler to build debug mode with no optimize.
 # We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# The -D_GLIBCXX_DEBUG setting tell compiler to compile std:: with debug
 # The -I gives the path to the includes needed to use with the htm.core library.
 # The -L gives the path to the shared htm.core library location at build time.
 # The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
-g++ -g -Og -o myapp -std=c++17  -I <path-to-repo>/build/Debug/include myapp.cpp -L <path-to-repo>/build/Debug/lib -lhtm_core -lpthread -ldl
+g++ -g -Og -o myapp -std=c++17 -D_GLIBCXX_DEBUG -I <path-to-repo>/build/Debug/include myapp.cpp -L <path-to-repo>/build/Debug/lib -lhtm_core -lpthread -ldl
 
 # Run myapp in the debugger
 export LD_LIBRARY_PATH=<path-to-repo>/build/Debug/lib:$LD_LIBRARY_PATH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -509,7 +509,7 @@ install(DIRECTORY ${cereal_INCLUDE_DIRS}/cereal
       FILES_MATCHING PATTERN "*.h*"
       PATTERN "*.hpp.in" EXCLUDE)
 
-install(FILES ${cpp-httplib_SOURCE_DIR}/httplib.h
+install(FILES ${cpp-httplib_INCLUDE_DIRS}/httplib.h
       DESTINATION include)
 
 install(DIRECTORY "${REPOSITORY_DIR}/external/common/include/"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -503,6 +503,14 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/htm
       FILES_MATCHING PATTERN "*.h*"
       PATTERN "*.hpp.in" EXCLUDE)
 
+install(DIRECTORY ${cereal_INCLUDE_DIRS}/cereal
+      MESSAGE_NEVER
+      DESTINATION include/
+      FILES_MATCHING PATTERN "*.h*"
+      PATTERN "*.hpp.in" EXCLUDE)
+
+install(FILES ${cpp-httplib_SOURCE_DIR}/httplib.h
+      DESTINATION include)
 
 install(DIRECTORY "${REPOSITORY_DIR}/external/common/include/"
       MESSAGE_NEVER

--- a/src/examples/napi_hello/DebugBuild.sh
+++ b/src/examples/napi_hello/DebugBuild.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Using GCC on linux ...
+# An example script to build for debug using GCC on linux ...
 # First build htm.core as debug from sources.
 #      cd <path-to-repo>
 #      mkdir -p build/scripts
@@ -10,10 +10,11 @@
 # Now build napi_hello
 # The -g -Og tells the compiler to build debug mode with no optimize.
 # We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# The -D_GLIBCXX_DEBUG setting says compile std:: with debug
 # The -I gives the path to the includes needed to use the htm.core library.
 # The -L gives the path to the shared htm.core library location at build time.
 # -lhtm_core says link with libhtm_core.so
-g++ -g -Og -o napi_hello -std=c++17  -I ../../../build/Debug/include myapp.cpp -L ../../../build/Debug/lib -lhtm_core -lpthread -ldl
+g++ -g -Og -o napi_hello -std=c++17 -D_GLIBCXX_DEBUG -I ../../../build/Debug/include myapp.cpp -L ../../../build/Debug/lib -lhtm_core -lpthread -ldl
 
 # Run napi_hello in the debugger
 # The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.

--- a/src/examples/napi_hello/DebugBuild.sh
+++ b/src/examples/napi_hello/DebugBuild.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+# Using GCC on linux ...
+# First build htm.core as debug from sources.
+#      cd <path-to-repo>
+#      mkdir -p build/scripts
+#      cd build/scripts
+#      cmake ../.. -DCMAKE_BUILD_TYPE=Debug
+#      make -j4 install
+#
+# Now build napi_hello
+# The -g -Og tells the compiler to build debug mode with no optimize.
+# We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# The -I gives the path to the includes needed to use the htm.core library.
+# The -L gives the path to the shared htm.core library location at build time.
+# -lhtm_core says link with libhtm_core.so
+g++ -g -Og -o napi_hello -std=c++17  -I ../../../build/Debug/include myapp.cpp -L ../../../build/Debug/lib -lhtm_core -lpthread -ldl
+
+# Run napi_hello in the debugger
+# The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
+export LD_LIBRARY_PATH=../../../build/Debug/lib:$LD_LIBRARY_PATH
+gdb napi_hello

--- a/src/examples/napi_hello/ReleaseBuild.sh
+++ b/src/examples/napi_hello/ReleaseBuild.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Using GCC on linux ...
+# An example script to build for Release using GCC on linux ...
 # First build htm.core as Release from sources.
 #      cd <path-to-repo>
 #      mkdir -p build/scripts
@@ -8,7 +8,7 @@
 #      make -j4 install
 #
 # Now build napi_hello
-# We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# We use -std=c++17 to get <filesystem> so you can avoid using the boost library.
 # The -I gives the path to the includes needed to use the htm.core library.
 # The -L gives the path to the shared htm.core library location at build time.
 g++ -o napi_hello -std=c++17  -I ../../../build/Release/include myapp.cpp -L ../../../build/Release/lib -lhtm_core -lpthread -ldl

--- a/src/examples/napi_hello/ReleaseBuild.sh
+++ b/src/examples/napi_hello/ReleaseBuild.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+# Using GCC on linux ...
+# First build htm.core as Release from sources.
+#      cd <path-to-repo>
+#      mkdir -p build/scripts
+#      cd build/scripts
+#      cmake ../..
+#      make -j4 install
+#
+# Now build napi_hello
+# We use -std=c++17 to get <filesystem> so we can avoid using the boost library.
+# The -I gives the path to the includes needed to use the htm.core library.
+# The -L gives the path to the shared htm.core library location at build time.
+g++ -o napi_hello -std=c++17  -I ../../../build/Release/include myapp.cpp -L ../../../build/Release/lib -lhtm_core -lpthread -ldl
+
+# Run napi_hello 
+# The LD_LIBRARY_PATH envirment variable points to the htm.core library location at runtime.
+export LD_LIBRARY_PATH=../../../build/Release/lib:$LD_LIBRARY_PATH
+./napi_hello

--- a/src/examples/napi_hello/napi_hello.cpp
+++ b/src/examples/napi_hello/napi_hello.cpp
@@ -16,10 +16,6 @@
  * --------------------------------------------------------------------- */
 
 #include <htm/engine/Network.hpp>
-#include <htm/utils/Random.hpp>
-#include <htm/utils/Log.hpp>
-#include <htm/ntypes/Value.hpp>
-#include <htm/utils/MovingAverage.hpp>
 #include <htm/algorithms/AnomalyLikelihood.hpp>
 #include <fstream>
 

--- a/src/examples/napi_hello/napi_hello.hpp
+++ b/src/examples/napi_hello/napi_hello.hpp
@@ -1,0 +1,20 @@
+/* ---------------------------------------------------------------------
+ * HTM Community Edition of NuPIC
+ * Copyright (C) 2013-2015, Numenta, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ * --------------------------------------------------------------------- */
+
+#include <htm/engine/Network.hpp>
+#include <htm/algorithms/AnomalyLikelihood.hpp>
+

--- a/src/examples/napi_hello/napi_hello_database.cpp
+++ b/src/examples/napi_hello/napi_hello_database.cpp
@@ -16,10 +16,6 @@
  * --------------------------------------------------------------------- */
 
 #include <htm/engine/Network.hpp>
-#include <htm/utils/Random.hpp>
-#include <htm/utils/Log.hpp>
-#include <htm/ntypes/Value.hpp>
-#include <htm/utils/MovingAverage.hpp>
 #include <htm/algorithms/AnomalyLikelihood.hpp>
 #include <fstream>
 

--- a/src/htm/engine/Region.hpp
+++ b/src/htm/engine/Region.hpp
@@ -38,6 +38,7 @@
 #include <htm/types/Serializable.hpp>
 #include <htm/types/Types.hpp>
 #include <htm/ntypes/Value.hpp>
+#include <htm/ntypes/Array.hpp>
 
 namespace htm {
 

--- a/src/htm/ntypes/Array.hpp
+++ b/src/htm/ntypes/Array.hpp
@@ -167,6 +167,7 @@
 #include <htm/ntypes/Dimensions.hpp>
 #include <htm/utils/Log.hpp>
 #include <htm/types/Serializable.hpp>
+#include <htm/types/Sdr.hpp>
 
 namespace htm {
 class Array : public ArrayBase {

--- a/src/htm/os/ImportFilesystem.hpp
+++ b/src/htm/os/ImportFilesystem.hpp
@@ -31,6 +31,7 @@
 //    Clang 7 has complete <filesystem> support for C++17
 //    Visual Studio 2017 15.7 (v19.14)supports <filesystem> with C++17
 //    MinGW has no support for filesystem.
+// To avoid requiring boost, on GCC and Clang use compile option -std=c++17
 //
 // If >= C++17 then
 //   use std::filesystem, if it exists
@@ -54,13 +55,8 @@
   #endif
 #else
   // C++11
-  #if (defined( __GNUC__ ) && __GNUC__ >= 8) || (defined(__clang_major__) && __clang_major__ >= 7)
-      #include <filesystem>
-      namespace fs = std::filesystem;
-  #else
-      #include <boost/filesystem.hpp>
-      #define USE_BOOST_FILESYSTEM 1
-  #endif
+  #include <boost/filesystem.hpp>
+  #define USE_BOOST_FILESYSTEM 1
 #endif
 
 #ifdef USE_BOOST_FILESYSTEM

--- a/src/htm/os/ImportFilesystem.hpp
+++ b/src/htm/os/ImportFilesystem.hpp
@@ -54,8 +54,13 @@
   #endif
 #else
   // C++11
-  #include <boost/filesystem.hpp>
-  #define USE_BOOST_FILESYSTEM 1
+  #if (defined( __GNUC__ ) && __GNUC__ >= 8) || (defined(__clang_major__) && __clang_major__ >= 7)
+      #include <filesystem>
+      namespace fs = std::filesystem;
+  #else
+      #include <boost/filesystem.hpp>
+      #define USE_BOOST_FILESYSTEM 1
+  #endif
 #endif
 
 #ifdef USE_BOOST_FILESYSTEM

--- a/src/htm/os/Timer.cpp
+++ b/src/htm/os/Timer.cpp
@@ -19,7 +19,6 @@
  * Generic OS Implementations for the OS class
  */
 
-#include <htm/os/Timer.hpp>
 
 #include <htm/utils/Random.hpp>
 #include <htm/utils/Log.hpp>
@@ -27,6 +26,12 @@
 #include <cmath> //for sins
 #include <sstream>
 #include <vector>
+
+namespace htm {
+static Real64 SPEED = -1; //for getSpeed()
+}
+#include <htm/os/Timer.hpp>
+
 
 namespace htm {
 

--- a/src/htm/os/Timer.hpp
+++ b/src/htm/os/Timer.hpp
@@ -99,7 +99,7 @@ private:
 
 }; // class Timer
 
-static Real64 SPEED = -1; //uninitialized, for getSpeed()
+extern Real64 SPEED; //for getSpeed()
 
 } // namespace htm
 


### PR DESCRIPTION
See Issue #885 

I tried making a copy of the napi_hello example and build it without using CMake.
This PR attempts to fix the problems that were found.

- cereal include files were not found
- cpp-htmlib include file was not found (would be needed by RESTapi examples.
- Global in htm/os/timer.cpp needed to be corrected.
- importFileSystem.hpp did not have the right logic for avoiding boost
- Added some sample build scripts
- Added comments to README.md
- Undefined references when compiling with GCC for debug mode (without Python).
