### PR TITLE
Fix init permanence distance from connected threshold: TM, SP

### DIFF
--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -447,7 +447,7 @@ void SpatialPooler::initialize(
 
   inhibitionRadius_ = 0;
 
-  connections_.initialize(numColumns_, synPermConnected_);
+  connections_.initialize(numColumns_, synPermConnected_, /*timeseries=*/false); //TODO try TS on
   for (Size i = 0; i < numColumns_; ++i) {
     connections_.createSegment( static_cast<CellIdx>(i) , 1 /* max segments per cell is fixed for SP to 1 */);
 

--- a/src/htm/algorithms/SpatialPooler.hpp
+++ b/src/htm/algorithms/SpatialPooler.hpp
@@ -71,7 +71,7 @@ public:
     UInt stimulusThreshold = 0u, 
     Real synPermInactiveDec = 0.008f,
     Real synPermActiveInc = 0.05f, 
-    Real synPermConnected = 0.1f,
+    Real synPermConnected = 0.2f,
     Real minPctOverlapDutyCycles = 0.001f,
     UInt dutyCyclePeriod = 1000u, 
     Real boostStrength = 0.0f,
@@ -221,7 +221,7 @@ public:
 	     UInt numActiveColumnsPerInhArea = 0,
              UInt stimulusThreshold = 0u,
              Real synPermInactiveDec = 0.01f, Real synPermActiveInc = 0.1f,
-             Real synPermConnected = 0.1f, Real minPctOverlapDutyCycles = 0.001f,
+             Real synPermConnected = 0.2f, Real minPctOverlapDutyCycles = 0.001f,
              UInt dutyCyclePeriod = 1000u, Real boostStrength = 0.0f,
              Int seed = 1, UInt spVerbosity = 0u, bool wrapAround = true);
 

--- a/src/htm/algorithms/TemporalMemory.cpp
+++ b/src/htm/algorithms/TemporalMemory.cpp
@@ -105,6 +105,7 @@ void TemporalMemory::initialize(
   NTA_CHECK(connectedPermanence >= 0.0 && connectedPermanence <= 1.0);
   NTA_CHECK(permanenceIncrement >= 0.0 && permanenceIncrement <= 1.0);
   NTA_CHECK(permanenceDecrement >= 0.0 && permanenceDecrement <= 1.0);
+  NTA_CHECK(fabs(connectedPermanence - initialPermanence) < 2*std::min(permanenceIncrement, permanenceDecrement)) << "Initial permanences should be with 2 increment(decrement) steps from the connected threshold. (Soft recommendation)."; 
   NTA_CHECK(minThreshold <= activationThreshold);
 
   // Save member variables

--- a/src/htm/algorithms/TemporalMemory.cpp
+++ b/src/htm/algorithms/TemporalMemory.cpp
@@ -130,7 +130,7 @@ void TemporalMemory::initialize(
   externalPredictiveInputs_ = externalPredictiveInputs;
 
   // Initialize member variables
-  connections_ = Connections(static_cast<CellIdx>(numberOfColumns() * cellsPerColumn_), connectedPermanence_);
+  connections_ = Connections(static_cast<CellIdx>(numberOfColumns() * cellsPerColumn_), connectedPermanence_, /*timeseries=*/false); //TODO try TS true
   rng_ = Random(seed);
 
   maxSegmentsPerCell_ = maxSegmentsPerCell;

--- a/src/htm/algorithms/TemporalMemory.hpp
+++ b/src/htm/algorithms/TemporalMemory.hpp
@@ -138,7 +138,7 @@ public:
       CellIdx         cellsPerColumn              = 32,
       SynapseIdx      activationThreshold         = 13,
       Permanence      initialPermanence           = 0.21,
-      Permanence      connectedPermanence         = 0.50,
+      Permanence      connectedPermanence         = 0.20,
       SynapseIdx      minThreshold                = 10,
       SynapseIdx      maxNewSynapseCount          = 20,
       Permanence      permanenceIncrement         = 0.10,
@@ -147,7 +147,7 @@ public:
       Int             seed                        = 42,
       SegmentIdx      maxSegmentsPerCell          = 255,
       SynapseIdx      maxSynapsesPerSegment       = 255,
-      bool            checkInputs                 = true,
+      bool            checkInputs                 = false,
       UInt            externalPredictiveInputs    = 0,
       ANMode	      anomalyMode 		  = ANMode::RAW
       );
@@ -158,7 +158,7 @@ public:
     CellIdx          cellsPerColumn           = 32,
     SynapseIdx       activationThreshold      = 13,
     Permanence    initialPermanence           = 0.21,
-    Permanence    connectedPermanence         = 0.50,
+    Permanence    connectedPermanence         = 0.20,
     SynapseIdx    minThreshold                = 10,
     SynapseIdx    maxNewSynapseCount          = 20,
     Permanence    permanenceIncrement         = 0.10,
@@ -167,7 +167,7 @@ public:
     Int           seed                        = 42,
     SegmentIdx    maxSegmentsPerCell          = 255,
     SynapseIdx    maxSynapsesPerSegment       = 255,
-    bool          checkInputs                 = true,
+    bool          checkInputs                 = false,
     UInt          externalPredictiveInputs    = 0,
     ANMode        anomalyMode                 = ANMode::RAW
     );


### PR DESCRIPTION
TM initial and connected synaptic weights were mistakenly (by our changes in the past) initialized too far away. The intention was/is to init close to the edge of "connected". 
- fixed in TM
- added init check to avoid this. 
- SP should initialize closer to the middle (now 0.2 from 0.1, ideally move to 0.5 all) 

This is a minor PR, ready to go as is. Changes doublechecked on NAB, no improvement/worse. 

PS: As a follow up, I'd like to simplify the synapse init logic: 
- drop Connection's argument `connectedPermanence` and hardcode this value (empirically no difference in 0.2, 0.5) 
- in SP, TM drop related args for connected threshold and initial synapse. 