### PR TITLE
Add method RDSE.check_parameters()

### DIFF
--- a/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
@@ -59,8 +59,8 @@ overlap in at least some of their bits. You can think of this as the radius of
 the input.)");
 
         py_RDSE_args.def_readwrite("resolution", &RDSE_Parameters::resolution,
-R"(Two inputs separated by greater than, or equal to the resolution are
-guaranteed to have different representations.)");
+R"(Two inputs separated by greater than, or equal to the resolution will
+in general have different representations.)");
 
         py_RDSE_args.def_readwrite("category", &RDSE_Parameters::category,
 R"(Member "category" means that the inputs are enumerated categories.
@@ -115,7 +115,6 @@ fields are filled in automatically.)");
             self.encode(value, *sdr);
             return sdr;
         });
-
 
 	// Serialization
 	// loadFromString

--- a/bindings/py/tests/encoders/rdse_test.py
+++ b/bindings/py/tests/encoders/rdse_test.py
@@ -27,7 +27,7 @@ from htm.bindings.encoders import RDSE, RDSE_Parameters
 class RDSE_Test(unittest.TestCase):
     def testConstructor(self):
         params1 = RDSE_Parameters()
-        params1.size     = 100
+        params1.size     = 1000
         params1.sparsity = .10
         params1.radius   = 10
         R1 = RDSE( params1 )
@@ -45,11 +45,11 @@ class RDSE_Test(unittest.TestCase):
 
     def testErrorChecks(self):
         params1 = RDSE_Parameters()
-        params1.size     = 100
+        params1.size     = 1000
         params1.sparsity = .10
         params1.radius   = 10
         R1 = RDSE( params1 )
-        A = SDR([10, 10])
+        A = SDR([100, 10])
         R1.encode( 33, A )
 
         # Test wrong input dimensions
@@ -61,7 +61,7 @@ class RDSE_Test(unittest.TestCase):
         params1.size = 0
         with self.assertRaises(RuntimeError):
             RDSE( params1 )
-        params1.size = 100
+        params1.size = 1000
 
         # Test invalid parameters, activeBits == 0
         params1.activeBits = 0
@@ -71,20 +71,20 @@ class RDSE_Test(unittest.TestCase):
 
         # Test missing activeBits
         params2 = RDSE_Parameters()
-        params2.size     = 100
+        params2.size     = 1000
         params2.radius   = 10
         with self.assertRaises(RuntimeError):
             RDSE( params2 )
         # Test missing resolution/radius
         params3 = RDSE_Parameters()
-        params3.size       = 100
+        params3.size       = 1000
         params3.activeBits = 10
         with self.assertRaises(RuntimeError):
             RDSE( params3 )
 
         # Test too many parameters: activeBits & sparsity
         params4 = RDSE_Parameters()
-        params4.size       = 100
+        params4.size       = 1000
         params4.sparsity   = .6
         params4.activeBits = 10
         params4.radius     = 4
@@ -92,33 +92,41 @@ class RDSE_Test(unittest.TestCase):
             RDSE( params4 )
         # Test too many parameters: resolution & radius
         params5 = RDSE_Parameters()
-        params5.size       = 100
+        params5.size       = 1000
         params5.activeBits = 10
         params5.radius     = 4
         params5.resolution = 4
         with self.assertRaises(RuntimeError):
             RDSE( params5 )
 
+        # Test for hash collision error.
+        params6 = RDSE_Parameters()
+        params6.size       = 100
+        params6.activeBits = 10
+        params6.radius     = 1
+        with self.assertRaises(RuntimeError):
+            RDSE( params6 )
+
     def testSparsityActiveBits(self):
         """ Check that these arguments are equivalent. """
         # Round sparsity up
         P = RDSE_Parameters()
-        P.size     = 100
-        P.sparsity = .0251
+        P.size     = 1000
+        P.sparsity = .02551
         P.radius   = 10
         R = RDSE( P )
-        assert( R.parameters.activeBits == 3 )
+        assert( R.parameters.activeBits == 26 )
         # Round sparsity down
         P = RDSE_Parameters()
-        P.size     = 100
-        P.sparsity = .0349
-        P.radius   = 10
+        P.size     = 1000
+        P.sparsity = .03049
+        P.radius   = 100
         R = RDSE( P )
-        assert( R.parameters.activeBits == 3 )
+        assert( R.parameters.activeBits == 30 )
         # Check activeBits
         P = RDSE_Parameters()
-        P.size       = 100
-        P.activeBits = 50 # No floating point issues here.
+        P.size       = 1000
+        P.activeBits = 500 # No floating point issues here.
         P.radius     = 10
         R = RDSE( P )
         assert( R.parameters.sparsity == .5 )
@@ -265,7 +273,7 @@ class RDSE_Test(unittest.TestCase):
         """        
         rdse_params = RDSE_Parameters()
         rdse_params.sparsity = 0.1
-        rdse_params.size = 100
+        rdse_params.size = 1000
         rdse_params.resolution = 0.1
         rdse_params.seed = 1997
 

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -760,7 +760,7 @@ std::ostream& operator<< (std::ostream& stream, const Connections& self)
   SynapseIdx  connectedMax  = 0;
   UInt        synapsesDead      = 0;
   UInt        synapsesSaturated = 0;
-  for( const auto cellData : self.cells_ )
+  for( const auto &cellData : self.cells_ )
   {
     const UInt numSegments = (UInt) cellData.segments.size();
     segmentsMin   = std::min( segmentsMin, numSegments );
@@ -826,7 +826,7 @@ bool Connections::operator==(const Connections &o) const {
 
   //also check underlying datastructures (segments, and subsequently synapses). Can be time consuming.
   //1.cells:
-  for(const auto cellD : cells_) {
+  for(const auto &cellD : cells_) {
     //2.segments:
     const auto& segments = cellD.segments;
     for(const auto seg : segments) {

--- a/src/htm/encoders/RandomDistributedScalarEncoder.cpp
+++ b/src/htm/encoders/RandomDistributedScalarEncoder.cpp
@@ -87,7 +87,7 @@ void RandomDistributedScalarEncoder::initialize( const RDSE_Parameters &paramete
     args_.seed = Random().getUInt32();
   }
 
-  NTA_CHECK(check_parameters()) << "Failed hash collision resistance check, please increase size and/or activeBits.";
+  NTA_CHECK(check_parameters()) << "Failed hash collision resistance check, please increase size, sparsity, and or activeBits.";
 }
 
 void RandomDistributedScalarEncoder::encode(Real64 input, SDR &output)

--- a/src/htm/encoders/RandomDistributedScalarEncoder.cpp
+++ b/src/htm/encoders/RandomDistributedScalarEncoder.cpp
@@ -86,6 +86,8 @@ void RandomDistributedScalarEncoder::initialize( const RDSE_Parameters &paramete
   while( args_.seed == 0u ) {
     args_.seed = Random().getUInt32();
   }
+
+  NTA_CHECK(check_parameters()) << "Failed hash collision resistance check.";
 }
 
 void RandomDistributedScalarEncoder::encode(Real64 input, SDR &output)
@@ -118,12 +120,28 @@ void RandomDistributedScalarEncoder::encode(Real64 input, SDR &output)
     // deviations in the sparsity or semantic similarity, depending on how
     // they're handled.
 
-    // Exercise for the reader: Calculate the probability of a hash collision
-    // and account for it in the sparsity.
-
     data[bucket] = 1u;
   }
   output.setDense( data );
+}
+
+bool RandomDistributedScalarEncoder::check_parameters() {
+  if( parameters.size >= 1000 && parameters.activeBits >= 10 ) {
+    return true;
+  }
+  const auto maximum_overlap = 0.33f;
+  const auto number_of_trials = 1000u;
+  SDR a({parameters.size});
+  SDR b({parameters.size});
+  a.randomize(parameters.sparsity);
+  for(auto i = 0u; i < number_of_trials; i++) {
+    b.randomize(parameters.sparsity);
+    Real overlap = Real(a.getOverlap(b)) / parameters.activeBits;
+    if( overlap > maximum_overlap ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 std::ostream & htm::operator<<(std::ostream & out, const RandomDistributedScalarEncoder &self)

--- a/src/htm/encoders/RandomDistributedScalarEncoder.cpp
+++ b/src/htm/encoders/RandomDistributedScalarEncoder.cpp
@@ -87,7 +87,7 @@ void RandomDistributedScalarEncoder::initialize( const RDSE_Parameters &paramete
     args_.seed = Random().getUInt32();
   }
 
-  NTA_CHECK(check_parameters()) << "Failed hash collision resistance check.";
+  NTA_CHECK(check_parameters()) << "Failed hash collision resistance check, please increase size and/or activeBits.";
 }
 
 void RandomDistributedScalarEncoder::encode(Real64 input, SDR &output)

--- a/src/htm/encoders/RandomDistributedScalarEncoder.hpp
+++ b/src/htm/encoders/RandomDistributedScalarEncoder.hpp
@@ -65,7 +65,7 @@ struct RDSE_Parameters
 
   /**
    * Member "resolution" Two inputs separated by greater than, or equal to the
-   * resolution are guaranteed to have different representations.
+   * resolution will in general have different representations.
    */
   Real resolution = 0.0f;
 
@@ -156,6 +156,14 @@ public:
   }
 private:
   RDSE_Parameters args_;
+
+  /**
+   * Check that this RDSE is resistant to hash collisions and will consistently
+   * produce good outputs.
+   *
+   * Returns true if the parameters are good.
+   */
+  bool check_parameters();
 };
 
 typedef RandomDistributedScalarEncoder RDSE;

--- a/src/htm/engine/Network.cpp
+++ b/src/htm/engine/Network.cpp
@@ -513,7 +513,7 @@ void Network::run(int n) {
       const std::shared_ptr<Region> r = p.second;
 
       for (const auto &inputTuple : r->getInputs()) {
-        for (const auto pLink : inputTuple.second->getLinks()) {
+        for (const auto &pLink : inputTuple.second->getLinks()) {
           pLink->shiftBufferedData();
         }
       }
@@ -695,7 +695,7 @@ void Network::post_load() {
     r->prepareInputs();
 
     for (const auto &inputTuple : r->getInputs()) {
-      for (const auto pLink : inputTuple.second->getLinks()) {
+      for (const auto &pLink : inputTuple.second->getLinks()) {
         pLink->shiftBufferedData();
       }
     }

--- a/src/test/unit/regions/RDSEEncoderRegionTest.cpp
+++ b/src/test/unit/regions/RDSEEncoderRegionTest.cpp
@@ -69,7 +69,7 @@ namespace testing
     Spec* ns = RDSEEncoderRegion::createSpec();
     VERBOSE << *ns << std::endl;
 
-    std::shared_ptr<Region> region1 = net.addRegion("region1", "RDSERegion", "{size: 100, activeBits: 10, resolution: 10}");  // use default configuration
+    std::shared_ptr<Region> region1 = net.addRegion("region1", "RDSERegion", "{size: 2000, activeBits: 40, resolution: 10}");  // use default configuration
     std::set<std::string> excluded = {"size", "seed", "activeBits", "resolution", "radius", "sparsity"};
     checkGetSetAgainstSpec(region1, EXPECTED_SPEC_COUNT, excluded, verbose);
     checkInputOutputsAgainstSpec(region1, verbose);
@@ -84,7 +84,7 @@ namespace testing
 	  size_t regionCntBefore = net.getRegions().size();
 
 	  VERBOSE << "Adding a built-in RDSEEncoderRegionTest..." << std::endl;
-	  std::shared_ptr<Region> region1 = net.addRegion("region1", "RDSEEncoderRegion", "{size: 100, activeBits: 10, resolution: 10}");
+	  std::shared_ptr<Region> region1 = net.addRegion("region1", "RDSEEncoderRegion", "{size: 2000, activeBits: 40, resolution: 10}");
 	  size_t regionCntAfter = net.getRegions().size();
 	  ASSERT_TRUE(regionCntBefore + 1 == regionCntAfter) << " Expected number of regions to increase by one.  ";
 	  ASSERT_TRUE(region1->getType() == "RDSEEncoderRegion") << " Expected type for region1 to be \"RDSEEncoderRegion\" but type is: " << region1->getType();
@@ -167,7 +167,7 @@ namespace testing
     // you can use JSON format as well)
 
     std::shared_ptr<Region> region1 = net.addRegion("region1", "FileInputRegion", "{activeOutputCount: 1}");
-    std::shared_ptr<Region> region2 = net.addRegion("region2", "RDSEEncoderRegion", "{size: 100, radius: 16, sparsity: 0.1}");
+    std::shared_ptr<Region> region2 = net.addRegion("region2", "RDSEEncoderRegion", "{size: 1000, radius: 16, sparsity: 0.1}");
     std::shared_ptr<Region> region3 = net.addRegion("region3", "SPRegion", "{columnCount: 200}");
     std::shared_ptr<Region> region4 = net.addRegion("region4", "FileOutputRegion", "{outputFile: '" + test_output_file + "'}");
 
@@ -186,7 +186,7 @@ namespace testing
 
 
 	  // check actual dimensions
-    ASSERT_EQ(region2->getParameterUInt32("size"), 100u);
+    ASSERT_EQ(region2->getParameterUInt32("size"), 1000u);
 
     VERBOSE << "Execute once." << std::endl;
     net.run(1);
@@ -233,7 +233,7 @@ namespace testing
 	  Network net3;
 
 	  VERBOSE << "Setup first network and save it" << std::endl;
-    std::shared_ptr<Region> n1region1 = net1.addRegion("region1", "RDSEEncoderRegion", "{size: 100, activeBits: 10, radius: 16}");
+    std::shared_ptr<Region> n1region1 = net1.addRegion("region1", "RDSEEncoderRegion", "{size: 2000, activeBits: 40, radius: 16}");
     std::shared_ptr<Region> n1region2 = net1.addRegion("region2", "SPRegion", "{columnCount: 200}");
     net1.link("region1", "region2", "", "", "encoded", "bottomUpIn");
     net1.initialize();


### PR DESCRIPTION
Hi everyone,

This PR adds a new check to the Random Distributed Scalar Encoder for sane Parameters. Bad RDSE parameters cause the RDSE to perform poorly and even to totally fail. The new checks are called automatically whenever an RDSE is created.

This works by experimentally measuring the hash collision probability. Currently it allows up to 33% of the encodings to collide before it returns an error, and it checks 1000 different random encodings for collisions.

For speed, this method is skipped if the RDSE parameters are obviously good. The heuristics for skipping the check are:
* size >= 1000 and
* activeBits >= 10

Fixes #777 