### PR TITLE
bump dependency versions

### DIFF
--- a/external/cereal.cmake
+++ b/external/cereal.cmake
@@ -20,7 +20,8 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/cereal.tar.gz")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/cereal.tar.gz")
 else()
-    set(URL https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz)
+	#set(URL https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz)
+	set(URL https://github.com/USCiLab/cereal/archive/64f50dbd5cecdaba785217e2b0aeea3a4f1cdfab.zip)
 endif()
 
 message(STATUS "obtaining Cereal")

--- a/external/cpp-httplib.cmake
+++ b/external/cpp-httplib.cmake
@@ -24,7 +24,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/cpp-httplib.zip")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/cpp-httplib.zip")
 else()
-    set(URL https://github.com/yhirose/cpp-httplib/archive/v0.7.6.zip)
+    set(URL https://github.com/yhirose/cpp-httplib/archive/v0.8.4.zip)
 endif()
 
 message(STATUS "obtaining cpp-httplib")

--- a/external/digestpp.cmake
+++ b/external/digestpp.cmake
@@ -20,7 +20,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/digestpp.zip")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/digestpp.zip")
 else()
-    set(URL https://github.com/kerukuro/digestpp/archive/36fa6ca2b85808bd171b13b65a345130dbe1d774.zip)
+    set(URL https://github.com/kerukuro/digestpp/archive/34ff2eeae397ed744d972d86b5a20f603b029fbd.zip)
 endif()
 
 message(STATUS "obtaining digestpp")

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -20,7 +20,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/eigen.tar.bz2")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/eigen.tar.bz2")
 else()
-	set(URL "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2")
+	set(URL "https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.bz2")
 endif()
 
 message(STATUS "obtaining Eigen")

--- a/external/gtest.cmake
+++ b/external/gtest.cmake
@@ -34,7 +34,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/googletest.tar.gz")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/googletest.tar.gz")
 else()
-    set(URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz)
+    set(URL https://github.com/abseil/googletest/archive/release-1.8.1.tar.gz)
 endif()
 
 #

--- a/external/gtest.cmake
+++ b/external/gtest.cmake
@@ -34,7 +34,7 @@
 if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/googletest.tar.gz")
     set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/googletest.tar.gz")
 else()
-    set(URL https://github.com/abseil/googletest/archive/release-1.8.1.tar.gz)
+    set(URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz)
 endif()
 
 #

--- a/external/libYaml.cmake
+++ b/external/libYaml.cmake
@@ -37,7 +37,7 @@ if(EXISTS   ${REPOSITORY_DIR}/build/ThirdParty/share/libyaml.zip)
 elif(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/libyaml.tar.gz)
     set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/libyaml.tar.gz)
 else()
-    set(URL "https://github.com/yaml/libyaml/archive/53f5b8682317d8dbe9082d1eeab3cc0e1adbb34b.zip")
+    set(URL "https://github.com/yaml/libyaml/archive/acd6f6f014c25e46363e718381e0b35205df2d83.zip")
     #set(URL "http://pyyaml.org/download/libyaml/yaml-0.2.2.tar.gz")
 endif()
 

--- a/external/sqlite3.cmake
+++ b/external/sqlite3.cmake
@@ -24,14 +24,14 @@
 #        high-reliability, full-featured, SQL database engine. SQLite is the most used 
 #        database engine in the world.
 #
-#            The current release is 3/32/3 (2020-06-18)
-#            The repository is at https://www.sqlite.org/2020/sqlite-autoconf-3320300.tar.gz
+#            The current release is 3.34.1 (2020-06-18)
+#            The repository is at https://www.sqlite.org/2020/sqlite-autoconf-3340100.tar.gz
 #
 #
 if(EXISTS   ${REPOSITORY_DIR}/build/ThirdParty/share/sqlite3.tar.gz)
     set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/sqlite3.tar.gz)
 else()
-    set(URL "https://www.sqlite.org/2020/sqlite-autoconf-3320300.tar.gz")
+    set(URL "https://www.sqlite.org/2021/sqlite-autoconf-3340100.tar.gz")
 endif()
 
 message(STATUS "Obtaining sqlite3")


### PR DESCRIPTION
use latest versions for our 3rd party deps