### PR TITLE
Overlap classifier

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -407,8 +407,8 @@ Argument output An SDR representing the winning columns after
         auto inhibitColumns_func = [](SpatialPooler& self, py::array& overlaps)
         {
             std::vector<htm::Real> overlapsVector(get_it<Real>(overlaps), get_end<Real>(overlaps));
-            std::vector<htm::UInt> activeColumnsVector;
-            self.inhibitColumns_(overlapsVector);
+            // converts from a vector of Real to a vector of UInt
+            std::vector<htm::UInt> activeColumnsVector = self.inhibitColumns_(overlapsVector);
 
             return py::array_t<UInt>( activeColumnsVector.size(), activeColumnsVector.data());
         };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,8 @@ set(algorithm_files
     htm/algorithms/AnomalyLikelihood.hpp
     htm/algorithms/Connections.cpp
     htm/algorithms/Connections.hpp
+    htm/algorithms/OverlapClassifier.cpp
+    htm/algorithms/OverlapClassifier.hpp
     htm/algorithms/SDRClassifier.cpp
     htm/algorithms/SDRClassifier.hpp
     htm/algorithms/SpatialPooler.cpp

--- a/src/examples/mnist/MNIST_SP.cpp
+++ b/src/examples/mnist/MNIST_SP.cpp
@@ -55,8 +55,10 @@
 using namespace std;
 using namespace htm;
 
+static UInt argmax(const PDF &data) { return UInt(max_element(data.begin(), data.end()) - data.begin()); }
+
 class MNIST {
-/**
+  /**
  * RESULTS:
  *
  * Order :	score			: column dim	: #pass : time(s): git commit	: comment

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -784,7 +784,7 @@ void SpatialPooler::updateBoostFactorsLocal_() {
     //optimization: In wrapAround, number of neighbors to be considered is solely a function of the inhibition radius,
     // the number of dimensions, and of the size of each of those dimenions. 
     // Or in non-wrap, if we use cached hood, we obtain the value the same as hood.size()
-    const UInt numNeighbors = static_cast<UInt>(hood.size() + 1); 
+    const UInt numNeighbors = static_cast<UInt>(hood.size()) + 1; 
     //start by adding the center ('i') which is not included in the hood
     localActivityDensity += activeDutyCycles_[i]; //include the center, which is 'i' (not included in hood)
 
@@ -831,7 +831,7 @@ UInt getAreaND_(const vector<UInt>& dimensions, const Real radius) {
 vector<CellIdx> SpatialPooler::inhibitColumns_(const vector<Real> &overlaps) const {
   Real density = localAreaDensity_; //option 1: used localAreaDensity
   if (numActiveColumnsPerInhArea_ > 0) { //option 2: used numActiveColumnsPerInhArea in constructor
-    const UInt inhibitionArea = getAreaND_(columnDimensions_, static_cast<const Real>(inhibitionRadius_)); 
+    const UInt inhibitionArea = getAreaND_(columnDimensions_, static_cast<Real>(inhibitionRadius_)); 
     NTA_ASSERT(inhibitionArea <= numColumns_);
     density = ((Real)numActiveColumnsPerInhArea_) / inhibitionArea;
     density = min(density, (Real)MAX_LOCALAREADENSITY);

--- a/src/htm/algorithms/SpatialPooler.cpp
+++ b/src/htm/algorithms/SpatialPooler.cpp
@@ -784,7 +784,7 @@ void SpatialPooler::updateBoostFactorsLocal_() {
     //optimization: In wrapAround, number of neighbors to be considered is solely a function of the inhibition radius,
     // the number of dimensions, and of the size of each of those dimenions. 
     // Or in non-wrap, if we use cached hood, we obtain the value the same as hood.size()
-    const UInt numNeighbors = hood.size() + 1; 
+    const UInt numNeighbors = static_cast<UInt>(hood.size() + 1); 
     //start by adding the center ('i') which is not included in the hood
     localActivityDensity += activeDutyCycles_[i]; //include the center, which is 'i' (not included in hood)
 
@@ -825,13 +825,13 @@ UInt getAreaND_(const vector<UInt>& dimensions, const Real radius) {
   }
   
   NTA_ASSERT(area >= 1);
-  return area;
+  return static_cast<UInt>(area);
 }
 
 vector<CellIdx> SpatialPooler::inhibitColumns_(const vector<Real> &overlaps) const {
   Real density = localAreaDensity_; //option 1: used localAreaDensity
   if (numActiveColumnsPerInhArea_ > 0) { //option 2: used numActiveColumnsPerInhArea in constructor
-    const UInt inhibitionArea = getAreaND_(columnDimensions_, inhibitionRadius_); 
+    const UInt inhibitionArea = getAreaND_(columnDimensions_, static_cast<const Real>(inhibitionRadius_)); 
     NTA_ASSERT(inhibitionArea <= numColumns_);
     density = ((Real)numActiveColumnsPerInhArea_) / inhibitionArea;
     density = min(density, (Real)MAX_LOCALAREADENSITY);
@@ -910,7 +910,7 @@ vector<CellIdx> SpatialPooler::inhibitColumnsLocal_(const vector<Real> &overlaps
     const auto& hood = neighborMap_.at(column);
     // Optimization: In wrapAround, number of neighbors to be considered is solely a function of the inhibition radius, 
     // the number of dimensions, and of the size of each of those dimenion
-    const UInt numNeighbors = hood.size();
+    const UInt numNeighbors = static_cast<UInt>(hood.size());
     //const UInt numDesiredLocalActive = static_cast<UInt>(ceil(density * (numNeighbors + 1)));
     const UInt numDesiredLocalActive = static_cast<UInt>(0.5f + (density * (numNeighbors + 1)));
     NTA_ASSERT(numDesiredLocalActive > 0);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set(algorithm_tests
 	   unit/algorithms/ConnectionsTest.cpp
 	   unit/algorithms/HelloSPTPTest.cpp
 	   unit/algorithms/SDRClassifierTest.cpp
+	   unit/algorithms/OverlapClassifierTest.cpp
 	   unit/algorithms/SpatialPoolerTest.cpp
 	   unit/algorithms/TemporalMemoryTest.cpp
 	   )

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1013,9 +1013,9 @@ TEST(SpatialPoolerTest, testUpdateBoostFactors) {
 
   { //test4: global inh + inh radius + boost str
   Real32 initActiveDutyCycles4[] = {0.1f, 0.3f, 0.02f, 0.04f, 0.7f, 0.12f};
-  Real32 initBoostFactors4[] = {0, 0, 0, 0, 0, 0};
-  vector<Real32> trueBoostFactors4 = {54.598148, 7.38906, 121.51038,
-	                              99.4843, 0.135335, 44.70118};
+  Real32 initBoostFactors4[] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+  vector<Real32> trueBoostFactors4 = {54.598148f, 7.38906f, 121.51038f,
+	                              99.4843f, 0.135335f, 44.70118f};
   vector<Real32> resultBoostFactors4(6, 0);
   sp.setGlobalInhibition(true);
   sp.setBoostStrength(10.0);

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1013,7 +1013,11 @@ TEST(SpatialPoolerTest, testUpdateBoostFactors) {
 
   { //test4: global inh + inh radius + boost str
   Real32 initActiveDutyCycles4[] = {0.1f, 0.3f, 0.02f, 0.04f, 0.7f, 0.12f};
+<<<<<<< HEAD
   Real32 initBoostFactors4[] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+=======
+  Real32 initBoostFactors4[] = {0, 0, 0, 0, 0, 0};
+>>>>>>> origin/master
   vector<Real32> trueBoostFactors4 = {54.598148f, 7.38906f, 121.51038f,
 	                              99.4843f, 0.135335f, 44.70118f};
   vector<Real32> resultBoostFactors4(6, 0);

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -1013,11 +1013,7 @@ TEST(SpatialPoolerTest, testUpdateBoostFactors) {
 
   { //test4: global inh + inh radius + boost str
   Real32 initActiveDutyCycles4[] = {0.1f, 0.3f, 0.02f, 0.04f, 0.7f, 0.12f};
-<<<<<<< HEAD
   Real32 initBoostFactors4[] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
-=======
-  Real32 initBoostFactors4[] = {0, 0, 0, 0, 0, 0};
->>>>>>> origin/master
   vector<Real32> trueBoostFactors4 = {54.598148f, 7.38906f, 121.51038f,
 	                              99.4843f, 0.135335f, 44.70118f};
   vector<Real32> resultBoostFactors4(6, 0);


### PR DESCRIPTION
This first push is a first cut for a work-in-progress.

This is a Classifier that uses Bit Overlap to map SDR's back to categories.
- Only one sample per value is sufficient for training (rather than hundreds).
- Uses an HTM approach rather than a NN approach.
- Does not forget values
- Handles more than one pattern per category and more than one category per pattern.

I don't have it quite worked out the math for the conversion from overlap counts to probability of a match returned in the PDF array of the infer( ) function.