### PR TITLE
Fix connections to reuse synapse data.

### DIFF
--- a/bindings/py/tests/algorithms/connections_test.py
+++ b/bindings/py/tests/algorithms/connections_test.py
@@ -216,13 +216,6 @@ class ConnectionsTest(unittest.TestCase):
     co.destroySynapse(syn1)
     self.assertEqual(co.numSynapses(), 0)
 
-    with pytest.raises(RuntimeError): # NTA_CHECK, data for removed synapse must not be accessible!
-      permRemoved = co.permanenceForSynapse(syn1)
-      assert permRemoved == perm1
-
-    # double remove should be just ignored
-    co.destroySynapse(syn1)
-    
 
 
   def testNumSynapses(self):

--- a/bindings/py/tests/algorithms/connections_test.py
+++ b/bindings/py/tests/algorithms/connections_test.py
@@ -430,17 +430,12 @@ class ConnectionsTest(unittest.TestCase):
     co = Connections(NUM_CELLS, 0.51)
     self.assertEqual(co.numSegments(), 0, "there are zero segments yet")
 
-    # removing while no segments exist
-    co.destroySegment(1)
-
     # successfully remove
     seg = co.createSegment(1, 20)
     self.assertEqual(co.numSegments(), 1)
     n = co.numConnectedSynapses(seg) #uses dataForSegment()
     co.destroySegment(seg)
     self.assertEqual(co.numSegments(), 0, "segment should have been removed")
-    with pytest.raises(RuntimeError):
-      n2 = co.numConnectedSynapses(seg)
     
 
 

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -210,14 +210,6 @@ Synapse Connections::createSynapse(Segment segment,
 }
 
 
-bool Connections::segmentExists_(const Segment segment) const {
-  if(segment >= segments_.size()) return false; //OOB segment
-
-  const SegmentData &segmentData = segments_[segment];
-  const vector<Segment> &segmentsOnCell = cells_[segmentData.cell].segments;
-  return (std::find(segmentsOnCell.cbegin(), segmentsOnCell.cend(), segment) != segmentsOnCell.cend()); //TODO if too slow, also create "fast" variant, as synapseExists_()
-}
-
 bool Connections::synapseExists_(const Synapse synapse, bool fast) const {
   if(synapse >= synapses_.size()) return false; //out of bounds. Can happen after serialization, where only existing synapses are stored.
 
@@ -268,7 +260,6 @@ void Connections::removeSynapseFromPresynapticMap_(
 
 
 void Connections::destroySegment(const Segment segment) {
-  if(not segmentExists_(segment)) return;
 
   for (auto h : eventHandlers_) {
     h.second->onDestroySegment(segment);

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -117,15 +117,16 @@ Segment Connections::createSegment(const CellIdx cell,
   NTA_ASSERT(numSegments(cell) <= maxSegmentsPerCell);
 
   //proceed to create a new segment
+  const SegmentData& segmentData = SegmentData(cell, iteration_, nextSegmentOrdinal_++);
   Segment segment;
   if (!destroyedSegments_.empty() ) { //reuse old, destroyed segs
     segment = destroyedSegments_.back();
     destroyedSegments_.pop_back();
+    segments_[segment] = segmentData;
   } else { //create a new segment
     NTA_CHECK(segments_.size() < std::numeric_limits<Segment>::max()) << "Add segment failed: Range of Segment (data-type) insufficinet size."
 	    << (size_t)segments_.size() << " < " << (size_t)std::numeric_limits<Segment>::max();
     segment = static_cast<Segment>(segments_.size());
-    const SegmentData& segmentData = SegmentData(cell, iteration_, nextSegmentOrdinal_++);
     segments_.push_back(segmentData);
   }
 

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -774,8 +774,8 @@ public:
    * @retval Number of synapses.
    */
   size_t numSynapses() const {
-    NTA_ASSERT(synapses_.size() >= destroyedSynapses_);
-    return synapses_.size() - destroyedSynapses_;
+    NTA_ASSERT(synapses_.size() >= destroyedSynapses_.size());
+    return synapses_.size() - destroyedSynapses_.size();
   }
 
   /**
@@ -874,7 +874,7 @@ private:
   std::vector<SegmentData> segments_;
   size_t                   destroyedSegments_ = 0;
   std::vector<SynapseData> synapses_;
-  size_t                   destroyedSynapses_ = 0;
+  std::vector<Synapse>     destroyedSynapses_;
   Permanence               connectedThreshold_; //TODO make const
   UInt32 iteration_ = 0;
 

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -453,7 +453,6 @@ public:
    * @retval Cell that this segment is on.
    */
   CellIdx cellForSegment(const Segment segment) const {
-    NTA_ASSERT(segmentExists_(segment));
     return segments_[segment].cell;
   }
 
@@ -492,11 +491,9 @@ public:
    * @retval Segment data.
    */
   const SegmentData &dataForSegment(const Segment segment) const {
-    NTA_CHECK(segmentExists_(segment));
     return segments_[segment];
   }
   SegmentData& dataForSegment(const Segment segment) { //editable access, needed by SP
-    NTA_CHECK(segmentExists_(segment));
     return segments_[segment];
   }
 
@@ -816,15 +813,6 @@ public:
   void unsubscribe(UInt32 token);
 
 protected:
-  /**
-   * Check whether this segment still exists on its cell.
-   *
-   * @param Segment
-   *
-   * @retval True if it's still in its cell's segment list.
-   */
-  bool segmentExists_(const Segment segment) const;
-
   /**
    * Check whether this synapse still exists "in Connections" ( on its segment).
    * After calling `synapseCreate()` this should be True, after `synapseDestroy()` 

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -755,9 +755,7 @@ public:
    * @retval Number of segments.
    */
   size_t numSegments() const { 
-	  NTA_ASSERT(segments_.size() >= destroyedSegments_);
-	  return segments_.size() - destroyedSegments_; 
-  }
+	  return segments_.size() - destroyedSegments_.size(); }
 
   /**
    * Gets the number of segments on a cell.
@@ -872,7 +870,7 @@ protected:
 private:
   std::vector<CellData>    cells_;
   std::vector<SegmentData> segments_;
-  size_t                   destroyedSegments_ = 0;
+  std::vector<Segment>     destroyedSegments_;
   std::vector<SynapseData> synapses_;
   std::vector<Synapse>     destroyedSynapses_;
   Permanence               connectedThreshold_; //TODO make const


### PR DESCRIPTION
Previously, some removed data was never cleared or reused and so the temporal memory would consume an unbounded amount of memory.