### PR TITLE
Changed prune segments to use a heuristic based on the synapse permanences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Also see [API_CHANGELOG](API_CHANGELOG.md).
 
+* Changed method of pruning segments from least-recently-used to a heuristic based on the synapse permanences.
+
 ## 2.1.0
 * REST API for htm.core
 * Ubuntu 20.04 LTS supported

--- a/src/htm/algorithms/Connections.cpp
+++ b/src/htm/algorithms/Connections.cpp
@@ -103,7 +103,7 @@ void Connections::pruneSegment_(const CellIdx& cell) {
 Segment Connections::createSegment(const CellIdx cell, 
 	                           const SegmentIdx maxSegmentsPerCell) {
 
-  //limit number of segmets per cell. If exceeded, remove the least recently used ones.
+  // Limit number of segments per cell. If exceeded, remove the least recently used ones.
   NTA_CHECK(maxSegmentsPerCell > 0);
   NTA_CHECK(cell < numCells());
   while (numSegments(cell) >= maxSegmentsPerCell) {
@@ -111,15 +111,15 @@ Segment Connections::createSegment(const CellIdx cell,
   }
   NTA_ASSERT(numSegments(cell) <= maxSegmentsPerCell);
 
-  //proceed to create a new segment
+  // Proceed to create a new segment.
   NTA_CHECK(segments_.size() < std::numeric_limits<Segment>::max()) << "Add segment failed: Range of Segment (data-type) insufficinet size."
 	    << (size_t)segments_.size() << " < " << (size_t)std::numeric_limits<Segment>::max();
   const Segment segment = static_cast<Segment>(segments_.size());
-  const SegmentData& segmentData = SegmentData(cell, iteration_, nextSegmentOrdinal_++);
+  const SegmentData& segmentData = SegmentData(cell, iteration_);
   segments_.push_back(segmentData);
 
   CellData &cellData = cells_[cell];
-  cellData.segments.push_back(segment); //assign the new segment to its mother-cell
+  cellData.segments.push_back(segment); // Assign the new segment to its mother-cell.
 
   for (auto h : eventHandlers_) {
     h.second->onCreateSegment(segment);
@@ -853,7 +853,6 @@ bool Connections::operator==(const Connections &o) const {
   NTA_CHECK(potentialSegmentsForPresynapticCell_ == o.potentialSegmentsForPresynapticCell_);
   NTA_CHECK(connectedSegmentsForPresynapticCell_ == o.connectedSegmentsForPresynapticCell_);
 
-  NTA_CHECK (nextSegmentOrdinal_ == o.nextSegmentOrdinal_ ) << "Connections equals: nextSegmentOrdinal_";
   NTA_CHECK (nextSynapseOrdinal_ == o.nextSynapseOrdinal_ ) << "Connections equals: nextSynapseOrdinal_";
 
   NTA_CHECK (timeseries_ == o.timeseries_ ) << "Connections equals: timeseries_";

--- a/src/htm/algorithms/Connections.hpp
+++ b/src/htm/algorithms/Connections.hpp
@@ -865,9 +865,9 @@ protected:
                               std::vector<Segment> &segmentsForPresynapticCell);
 
   /** 
-   *  Remove least recently used Segment from cell. 
+   *  Remove least useful Segment from cell. 
    */
-  void pruneLRUSegment_(const CellIdx& cell);
+  void pruneSegment_(const CellIdx& cell);
 
 private:
   std::vector<CellData>    cells_;

--- a/src/htm/algorithms/TemporalMemory.cpp
+++ b/src/htm/algorithms/TemporalMemory.cpp
@@ -390,12 +390,6 @@ void TemporalMemory::activateDendrites(const bool learn,
   }
   const auto compareSegments = [&](const Segment a, const Segment b) { return connections.compareSegments(a, b); };
   std::sort( activeSegments_.begin(), activeSegments_.end(), compareSegments); //SDR requires sorted when constructed from activeSegments_
-  // Update segment bookkeeping.
-  if (learn) {
-    for (const auto segment : activeSegments_) {
-      connections_.dataForSegment(segment).lastUsed = connections.iteration(); //TODO the destroySegments based on LRU is expensive. Better random? or "energy" based on sum permanences?
-    }
-  }
 
   // Matching segments, potential synapses.
   matchingSegments_.clear();


### PR DESCRIPTION
Hi,

I ran into an issue with the method `Connections::pruneLruSegment_`. My program learns with the TM for a while, and then the inputs are interrupted with random noise, and when the normal input returns all of the segments are gone. Here is what happened:
1) Normal inputs are given to the TM and the TM learns a bunch of stuff.
2) The inputs are interrupted with random noise for at least 50 timesteps.
3) When the TM fails to predict the inputs, then it makes new segments to learn the current input. Random inputs are unpredictable so when they are presented the TM creates new segments.
4) The random inputs cause the TM to reach its maximum number of segments, at which point it will need to deletes a segment.
5) The Least Recently Used segments are removed, which are all of the old segments from the beginning of the experiment. But those old segments were the only segments which had actually learned anything!

My solution is to replace "Least Recently Used" with "Least Useful" and then I invented a heuristic to determine how useful a segment is.
> Heuristic = sum(synapse.permanence ^ power for synapse on segment)

Where power is a positive integer.
This heuristic favors keeping segments which have many strong synapses over segments with fewer or weaker synapses.

This appears to work for me, but before it's merged I'd really like to see a before/after comparison on NAB.