### PR TITLE
Serialization format

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
@@ -205,6 +205,17 @@ R"(Returns pair of:
             auto C = new Connections();
             C->load( buf );
             return C; } );
+            
+		// saving and loading from file
+    py_Connections.def("saveToFile",
+     static_cast<void (htm::Connections::*)(std::string, std::string) const>(&htm::Connections::saveToFile), 
+     py::arg("file"), py::arg("fmt") = "BINARY",
+     "Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML'.");
+
+    py_Connections.def("loadFromFile",    
+     static_cast<void (htm::Connections::*)(std::string, std::string)>(&htm::Connections::loadFromFile), 
+     py::arg("file"), py::arg("fmt") = "BINARY",
+     "Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). ");
 
   } // End function init_Connections
 }   // End namespace htm_ext

--- a/bindings/py/cpp_src/bindings/algorithms/py_SDRClassifier.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SDRClassifier.cpp
@@ -92,22 +92,34 @@ Use "numpy.argmax" to find the category with the greatest probablility.)",
 
             py::arg("pattern"));
 
-        py_Classifier.def("learn", &Classifier::learn,
+        py_Classifier.def("learn", 
+          static_cast<void (htm::Classifier::*)(const htm::SDR&, const std::vector<UInt>&)>(&Classifier::learn),
 R"(Learn from example data.
-
 Argument pattern is the SDR containing the active input bits.
-
 Argument classification is the current category or bucket index.
 This may also be a list for when the input has multiple categories.)",
                 py::arg("pattern"),
                 py::arg("classification"));
 
-        py_Classifier.def("learn", [](Classifier &self, const SDR &pattern, UInt categoryIdx)
-            { self.learn( pattern, {categoryIdx} ); },
+        py_Classifier.def("learn", 
+          static_cast<void (htm::Classifier::*)(const htm::SDR&, UInt)>(&Classifier::learn),
                 py::arg("pattern"),
                 py::arg("classification"));
+                
+				// saving and loading from file
+        py_Classifier.def("saveToFile",
+         static_cast<void (htm::Classifier::*)(std::string, std::string) const>(&htm::Classifier::saveToFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         "Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML'.");
 
-        // TODO: Pickle support
+        py_Classifier.def("loadFromFile",    
+         static_cast<void (htm::Classifier::*)(std::string, std::string)>(&htm::Classifier::loadFromFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         "Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). ");
+
+
+
+        // Pickle support
 
         // pickle
         // https://github.com/pybind/pybind11/issues/1061
@@ -197,7 +209,7 @@ Returns a dictionary whos keys are prediction steps, and values are PDFs.
 See help(Classifier.infer) for details about PDFs.)",
             py::arg("pattern"));
 
-        py_Predictor.def("learn", &Predictor::learn,
+        py_Predictor.def("learn", static_cast<void (htm::Predictor::*)(UInt, const htm::SDR&, const std::vector<UInt>&)>(&Predictor::learn),
 R"(Learn from example data.
 
 Argument recordNum is an incrementing integer for each record.
@@ -211,13 +223,22 @@ This may also be a list for when the input has multiple categories.)",
             py::arg("pattern"),
             py::arg("classification"));
 
-        py_Predictor.def("learn", [](Predictor &self, UInt recordNum, const SDR &pattern, UInt categoryIdx)
-            { self.learn( recordNum, pattern, {categoryIdx} ); },
+        py_Predictor.def("learn", static_cast<void (htm::Predictor::*)(UInt, const htm::SDR&, UInt)>(&Predictor::learn),
                 py::arg("recordNum"),
                 py::arg("pattern"),
                 py::arg("classification"));
 
-        // TODO: Pickle support
+       py_Predictor.def("saveToFile",
+         static_cast<void (htm::Predictor::*)(std::string, std::string) const>(&htm::Predictor::saveToFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML')");
+
+       py_Predictor.def("loadFromFile",    
+         static_cast<void (htm::Predictor::*)(std::string, std::string)>(&htm::Predictor::loadFromFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). )");
+
+        // Pickle support
 
         // pickle
         // https://github.com/pybind/pybind11/issues/1061

--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -247,11 +247,15 @@ Argument wrapAround boolean value that determines whether or not inputs
         py_SpatialPooler.def("setMinPctOverlapDutyCycles", &SpatialPooler::setMinPctOverlapDutyCycles);
 				
 				// saving and loading from file
-        py_SpatialPooler.def("saveToFile", 
-				    [](SpatialPooler &self, const std::string& filename) {self.saveToFile(filename,SerializableFormat::BINARY); });  
-				
-        py_SpatialPooler.def("loadFromFile",
-				    [](SpatialPooler &self, const std::string& filename) { return self.loadFromFile(filename,SerializableFormat::BINARY); }); 
+       py_SpatialPooler.def("saveToFile",
+         static_cast<void (htm::SpatialPooler::*)(std::string, std::string) const>(&htm::SpatialPooler::saveToFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML')");
+
+       py_SpatialPooler.def("loadFromFile",    
+         static_cast<void (htm::SpatialPooler::*)(std::string, std::string)>(&htm::SpatialPooler::loadFromFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). )");
 				
 
         // loadFromString, loads SP from a JSON encoded string produced by writeToString().
@@ -259,7 +263,8 @@ Argument wrapAround boolean value that determines whether or not inputs
         {
             std::stringstream inStream(inString);
             self.load(inStream, JSON);
-        });
+        },
+R"(See also standard library function: pickle.loads(...))");
 
         // writeToString, save SP to a JSON encoded string usable by loadFromString()
         py_SpatialPooler.def("writeToString", [](const SpatialPooler& self)
@@ -271,7 +276,8 @@ Argument wrapAround boolean value that determines whether or not inputs
             self.save(os, JSON);
 
             return os.str();
-        });
+        },
+R"(See also standard library function: pickle.dumps(...))");
 
         // compute
         py_SpatialPooler.def("compute", [](SpatialPooler& self, const SDR& input, const bool learn, SDR& output)

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -204,10 +204,7 @@ R"(See also standard library function: pickle.dumps(...))");
             self.load(inStream, JSON);
         },
 R"(See also standard library function: pickle.loads(...))");
-<<<<<<< HEAD
-=======
 
->>>>>>> 5a25f9b05217e3403924cf4f27dd5437957b4bc4
 
         py_HTM.def(py::pickle(
             [](const HTM_t& self)

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -175,11 +175,15 @@ Argument anomalyMode (optional, default ANMode::RAW) selects mode for `TM.anomal
                            py::scoped_estream_redirect>());
 
 				// saving and loading from file
-        py_HTM.def("saveToFile",
-				    [](TemporalMemory &self, const std::string& filename) {self.saveToFile(filename,SerializableFormat::BINARY); });
+       py_HTM.def("saveToFile",
+         static_cast<void (htm::TemporalMemory::*)(std::string, std::string) const>(&htm::TemporalMemory::saveToFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML')");
 
-        py_HTM.def("loadFromFile",
-				    [](TemporalMemory &self, const std::string& filename) { return self.loadFromFile(filename,SerializableFormat::BINARY); });
+       py_HTM.def("loadFromFile",    
+         static_cast<void (htm::TemporalMemory::*)(std::string, std::string)>(&htm::TemporalMemory::loadFromFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). )");
 
         // writeToString, save TM to a JSON encoded string usable by loadFromString()
         py_HTM.def("writeToString", [](const TemporalMemory& self)
@@ -191,14 +195,15 @@ Argument anomalyMode (optional, default ANMode::RAW) selects mode for `TM.anomal
             self.save(os, JSON);
 
             return os.str();
-        });
+        },
+R"(See also standard library function: pickle.dumps(...))");
         // loadFromString, loads TM from a JSON encoded string produced by writeToString().
         py_HTM.def("loadFromString", [](TemporalMemory& self, const std::string& inString)
         {
             std::stringstream inStream(inString);
             self.load(inStream, JSON);
-        });
-
+        },
+R"(See also standard library function: pickle.loads(...))");
 
         // pickle
         // https://github.com/pybind/pybind11/issues/1061

--- a/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
@@ -117,13 +117,13 @@ fields are filled in automatically.)");
         });
 
 	// Serialization
-	// loadFromString
+  // loadFromString
         py_RDSE.def("loadFromString", [](RDSE& self, const py::bytes& inString) {
           std::stringstream inStream(inString.cast<std::string>());
           self.load(inStream, JSON);
         });
 
-        // writeToString
+  // writeToString
         py_RDSE.def("writeToString", [](const RDSE& self) {
           std::ostringstream os;
           os.flags(ios::scientific);
@@ -133,24 +133,29 @@ fields are filled in automatically.)");
        });
 
 	// pickle
-        py_RDSE.def(py::pickle(
+       py_RDSE.def(py::pickle(
           [](const RDSE& self) {
             std::stringstream ss;
             self.save(ss);
             return py::bytes( ss.str() );
           },
           [](py::bytes &s) {
-	    std::stringstream ss( s.cast<std::string>() );
-	    std::unique_ptr<RDSE> self(new RDSE());
+            std::stringstream ss( s.cast<std::string>() );
+            std::unique_ptr<RDSE> self(new RDSE());
             self->load(ss);
             return self;
-        }));
+       }));
 
-        py_RDSE.def("saveToFile",
-	  [](RDSE &self, const std::string& filename) { self.saveToFile(filename, SerializableFormat::BINARY); });
+  // loadFromFile
+       py_RDSE.def("saveToFile",
+         static_cast<void (htm::RDSE::*)(std::string, std::string) const>(&htm::RDSE::saveToFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML')");
 
-        py_RDSE.def("loadFromFile",
-	  [](RDSE &self, const std::string& filename) { return self.loadFromFile(filename, SerializableFormat::BINARY); });
+       py_RDSE.def("loadFromFile",    
+         static_cast<void (htm::RDSE::*)(std::string, std::string)>(&htm::RDSE::loadFromFile), 
+         py::arg("file"), py::arg("fmt") = "BINARY",
+         R"(Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). )");
 
 
     }

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -19,6 +19,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+#include <pybind11/iostream.h>
+#include <sstream>
 namespace py = pybind11;
 
 #include <htm/encoders/ScalarEncoder.hpp>
@@ -122,5 +124,67 @@ fields are filled in automatically.)");
         self.encode( value, *output );
         return output; },
 R"()");
+
+// Serialization
+// loadFromString
+    py_ScalarEnc.def("loadFromString", [](ScalarEncoder& self, const py::bytes& inString) {
+      std::stringstream inStream(inString.cast<std::string>());
+      self.load(inStream, JSON);
+    });
+
+    // writeToString
+    py_ScalarEnc.def("writeToString", [](const ScalarEncoder& self) {
+      std::ostringstream os;
+      os.flags(std::ios_base::scientific);
+      os.precision(std::numeric_limits<double>::digits10 + 1);
+      self.save(os, JSON); // see serialization in bindings for SP, py_SpatialPooler.cpp for explanation
+      return py::bytes( os.str() );
+   });
+
+  // pickle
+  py_ScalarEnc.def(py::pickle( 
+  [](const ScalarEncoder& enc) // __getstate__
+  {
+    std::stringstream ss;
+    enc.save(ss);
+
+  /* The values in stringstream are binary so pickle will get confused
+   * trying to treat it as utf8 if you just return ss.str().
+   * So we must treat it as py::bytes.  Some characters could be null values.
+   */
+    return py::bytes( ss.str() );
+  },
+
+  [](py::bytes &s)   // __setstate__
+  {
+  /* pybind11 will pass in the bytes array without conversion.
+   * so we should be able to just create a string to initalize the stringstream.
+   */
+    std::stringstream ss( s.cast<std::string>() );
+    std::unique_ptr<ScalarEncoder> enc(new ScalarEncoder());
+    enc->load(ss);
+
+  /*
+   * The __setstate__ part of the py::pickle() is actually a py::init() with some options.
+   * So the return value can be the object returned by value, by pointer,
+   * or by container (meaning a unique_ptr). SP has a problem with the copy constructor
+   * and pointers have problems knowing who the owner is so lets use unique_ptr.
+   * See: https://pybind11.readthedocs.io/en/stable/advanced/classes.html#custom-constructors
+   */
+    return enc;
+  }));
+
+// loadFromFile
+//    
+   py_ScalarEnc.def("saveToFile",
+                     static_cast<void (htm::ScalarEncoder::*)(std::string, std::string) const>(&htm::ScalarEncoder::saveToFile), 
+                     py::arg("file"), py::arg("fmt") = "BINARY",
+R"(Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML')");
+
+   py_ScalarEnc.def("loadFromFile",    static_cast<void (htm::ScalarEncoder::*)(std::string, std::string)>(&htm::ScalarEncoder::loadFromFile), 
+                     py::arg("file"), py::arg("fmt") = "BINARY",
+R"(Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). )");
+
+
   }
 }

--- a/bindings/py/cpp_src/bindings/encoders/py_SimHashDocumentEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_SimHashDocumentEncoder.cpp
@@ -275,22 +275,17 @@ Documents can contain any number of tokens > 0. Token order in the document is
     /**
      * Serialization
      */
-    // file out
+    // loadFromFile
     py_SimHashDocumentEncoder.def("saveToFile",
-      [](SimHashDocumentEncoder &self, const std::string& filename) {
-        self.saveToFile(filename, SerializableFormat::BINARY);
-      },
-R"(
-Serialize current encoder instance out to a file.
-)");
-    // file in
-    py_SimHashDocumentEncoder.def("loadFromFile",
-	    [](SimHashDocumentEncoder &self, const std::string& filename) {
-        return self.loadFromFile(filename, SerializableFormat::BINARY);
-      },
-R"(
-Deserialize file contents into current object.
-)");
+      static_cast<void (htm::SimHashDocumentEncoder::*)(std::string, std::string) const>(&htm::SimHashDocumentEncoder::saveToFile), 
+      py::arg("file"), py::arg("fmt") = "BINARY",
+      R"(Serializes object to file. file: filename to write to.  fmt: format, one of 'BINARY', 'PORTABLE', 'JSON', or 'XML')");
+
+    py_SimHashDocumentEncoder.def("loadFromFile",    
+      static_cast<void (htm::SimHashDocumentEncoder::*)(std::string, std::string)>(&htm::SimHashDocumentEncoder::loadFromFile), 
+      py::arg("file"), py::arg("fmt") = "BINARY",
+      R"(Deserializes object from file. file: filename to read from.  fmt: format recorded by saveToFile(). )");
+
     // string out
     py_SimHashDocumentEncoder.def("writeToString",
         [](const SimHashDocumentEncoder& self) {

--- a/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
+++ b/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
@@ -435,8 +435,8 @@ namespace htm_ext
 
         py_Network.def("save",      &htm::Network::save)
             .def("load",            &htm::Network::load)
-            .def("saveToFile",      &htm::Network::saveToFile, py::arg("file"), py::arg("fmt") = SerializableFormat::BINARY)
-            .def("loadFromFile",    &htm::Network::loadFromFile, py::arg("file"), py::arg("fmt") = SerializableFormat::BINARY)
+            .def("saveToFile",      static_cast<void (htm::Network::*)(std::string, std::string) const>(&htm::Network::saveToFile), py::arg("file"), py::arg("fmt") = "BINARY")
+            .def("loadFromFile",    static_cast<void (htm::Network::*)(std::string, std::string)>(&htm::Network::loadFromFile), py::arg("file"), py::arg("fmt") = "BINARY")
             .def("__eq__",          &htm::Network::operator==);
             
         py_Network.def(py::pickle(

--- a/bindings/py/tests/algorithms/spatial_pooler_test.py
+++ b/bindings/py/tests/algorithms/spatial_pooler_test.py
@@ -238,9 +238,9 @@ class SpatialPoolerTest(unittest.TestCase):
      
      # The SP now has some data in it, try serialization.  
      file = "spatial_pooler_test_save2.bin"
-     sp.saveToFile(file)
+     sp.saveToFile(file, "PORTABLE")
      sp3 = SP()
-     sp3.loadFromFile(file)
+     sp3.loadFromFile(file, "PORTABLE")
      self.assertEqual(str(sp), str(sp3), "HTM SpatialPooler serialization (using saveToFile/loadFromFile) failed.")
      os.remove(file)
 

--- a/bindings/py/tests/algorithms/temporal_memory_test.py
+++ b/bindings/py/tests/algorithms/temporal_memory_test.py
@@ -99,7 +99,6 @@ class TemporalMemoryBindingsTest(unittest.TestCase):
                      "Simple NuPIC TemporalMemory pickle/unpickle failed.")
 
 
-  @pytest.mark.skip(reason="Fails with rapidjson internal assertion -- indicates a bad serialization")
   def testNupicTemporalMemorySavingToString(self):
     """Test writing to and reading from TemporalMemory."""
     inputs = SDR( 100 ).randomize( .05 )
@@ -127,9 +126,9 @@ class TemporalMemoryBindingsTest(unittest.TestCase):
 
     # The TM now has some data in it, try serialization.
     file = "temporalMemory_test_save2.bin"
-    tm.saveToFile(file)
+    tm.saveToFile(file, "JSON")
     tm3 = TM()
-    tm3.loadFromFile(file)
+    tm3.loadFromFile(file, "JSON")
     self.assertEqual(str(tm), str(tm3), "TemporalMemory serialization (using saveToFile/loadFromFile) failed.")
     os.remove(file)
 

--- a/bindings/py/tests/encoders/rdse_test.py
+++ b/bindings/py/tests/encoders/rdse_test.py
@@ -304,3 +304,32 @@ class RDSE_Test(unittest.TestCase):
         SDR_loaded = rdse_loaded.encode(value_to_encode)
 
         assert(SDR_original == SDR_loaded)
+        
+    def testJSONSerialization(self):
+        """
+        This test is to insure that Python can access the C++ serialization functions.
+        Serialization is tested more completely in C++ unit tests. Just checking 
+        that Python can access it.
+        """
+        rdse_params = RDSE_Parameters()
+        rdse_params.sparsity = 0.1
+        rdse_params.size = 1000
+        rdse_params.resolution = 0.1
+        rdse_params.seed = 1997
+
+        rdse = RDSE(rdse_params)
+        filename = 'RDSE_testPickle'
+        rdse.saveToFile(filename, 'JSON')
+        
+        """
+        rdse_loaded =  RDSE
+        rdse_loaded.loadFromFile(filename, 'JSON')
+        
+        value_to_encode = 69003        
+        SDR_original = rdse.encode(value_to_encode)
+        SDR_loaded = rdse_loaded.encode(value_to_encode)
+
+        assert(SDR_original == SDR_loaded)
+        """
+        
+        

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -301,6 +301,27 @@ class ScalarEncoder_Test(unittest.TestCase):
         assert( mtr.activationFrequency.max() < 1.75 * .10 )
         assert( mtr.overlap.min() > .85 )
 
-    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/htm.core/issues/160")
     def testPickle(self):
-        assert(False) # TODO: Unimplemented
+      p = ScalarEncoderParameters()
+      p.size       = 100
+      p.activeBits = 10
+      p.minimum    = 0
+      p.maximum    = 20
+      p.clipInput  = True
+
+      enc = ScalarEncoder( p )
+      import pickle
+
+      picklestr = pickle.dumps(enc)
+      enc2 = pickle.loads(picklestr)
+      #assert enc.parameters == enc2.parameters
+
+      assert enc.size == enc2.size
+
+      out =  SDR( enc.parameters.size )
+      out2 = SDR( enc2.parameters.size )
+      enc.encode(10, out)
+      enc2.encode(10, out2)
+      assert out == out2
+      #TODO add enc == enc2
+

--- a/bindings/py/tests/encoders/simhash_document_encoder_test.py
+++ b/bindings/py/tests/encoders/simhash_document_encoder_test.py
@@ -24,6 +24,7 @@ import pytest
 import random
 import sys
 import unittest
+import os
 
 from htm.bindings.encoders import SimHashDocumentEncoder, \
     SimHashDocumentEncoderParameters
@@ -231,7 +232,6 @@ class SimHashDocumentEncoder_Test(unittest.TestCase):
         assert(output4 != output5)
 
     # Test de/serialization via Pickle method
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason="Fails for python2 with segmentation fault")
     def testSerializePickle(self):
         vocab = {
             "hear": 2, "nothing": 4, "but": 1, "a": 1, "rushing": 4,
@@ -256,6 +256,41 @@ class SimHashDocumentEncoder_Test(unittest.TestCase):
         assert(enc1.parameters.size == enc2.parameters.size)
         assert(enc1.parameters.activeBits == enc2.parameters.activeBits)
         assert(output1 == output2)
+        
+    # Test de/serialization via saveToFile() and loadFromFile() methods
+    def testSerializeToFile(self):
+        vocab = {
+            "hear": 2, "nothing": 4, "but": 1, "a": 1, "rushing": 4,
+            "sound": 3}
+        document = [
+            "hear", "any", "sound", "sound", "louder", "but", "walls"]
+
+        params = SimHashDocumentEncoderParameters()
+        params.size = 400
+        params.sparsity = 0.33
+        params.encodeOrphans = True
+        params.vocabulary = vocab
+
+        enc1 = SimHashDocumentEncoder(params)
+        # The SimHashDocumentEncoder now has some data in it, try serialization.
+        file = "SimHashDocumentEncoder_test_save2.json"
+        enc1.saveToFile(file, "JSON")
+        output1 = enc1.encode(document)
+        
+        # change the parameters so we know the params were replaced from contents in file.
+        # Note: we should have constructor without parameters for this situation.
+        params.size = 10
+        params.sparsity = 0.5  
+        enc2 = SimHashDocumentEncoder(params)
+        enc2.loadFromFile(file, "JSON")
+        os.remove(file)
+        
+        output2 = enc2.encode(document)
+        assert(enc1.size == enc2.size)
+        assert(enc1.parameters.size == enc2.parameters.size)
+        assert(enc1.parameters.activeBits == enc2.parameters.activeBits)
+        
+        
 
     # Test de/serialization via String
     def testSerializeString(self):
@@ -284,7 +319,7 @@ class SimHashDocumentEncoder_Test(unittest.TestCase):
         assert(enc1.parameters.activeBits != enc2.parameters.activeBits)
 
         enc2.loadFromString(serialized)
-        output2 = enc1.encode(document)
+        output2 = enc2.encode(document)
 
         assert(enc1.size == enc2.size)
         assert(enc1.parameters.size == enc2.parameters.size)

--- a/src/htm/algorithms/SDRClassifier.hpp
+++ b/src/htm/algorithms/SDRClassifier.hpp
@@ -138,6 +138,7 @@ public:
    * @param pattern:  The active input bit SDR.
    * @param categoryIdxList:  The current categories or bucket indices.
    */
+  void learn(const SDR & pattern, UInt categoryIdx);
   void learn(const SDR & pattern, const std::vector<UInt> & categoryIdxList);
 
   CerealAdapter;
@@ -276,9 +277,8 @@ public:
    * @param pattern: The active input SDR.
    * @param bucketIdxList: Vector of the current value bucket indices or categories.
    */
-  void learn(const UInt recordNum, 
-	     const SDR &pattern,
-             const std::vector<UInt> &bucketIdxList);
+  void learn(const UInt recordNum, const SDR &pattern, UInt bucketIdx);
+  void learn(const UInt recordNum, const SDR &pattern, const std::vector<UInt> &bucketIdxList);
 
   CerealAdapter;
   template<class Archive>

--- a/src/htm/encoders/ScalarEncoder.hpp
+++ b/src/htm/encoders/ScalarEncoder.hpp
@@ -24,6 +24,7 @@
 #define NTA_ENCODERS_SCALAR
 
 #include <htm/types/Types.hpp>
+#include <htm/utils/Log.hpp>
 #include <htm/encoders/BaseEncoder.hpp>
 
 namespace htm {

--- a/src/htm/engine/Network.hpp
+++ b/src/htm/engine/Network.hpp
@@ -149,22 +149,23 @@ public:
    * @{
    */
   /**
-   *    saveToFile(path)          Open a file and stream to it. (Binary)
+   *    saveToFile(path [, fmt])  Open a file and stream to it. 
    *    save(ostream f [, fmt])   Stream to your stream.  
    *    f << net;                 Output human readable text. 
    *
-   *    loadFromFile(path)
+   *    loadFromFile(path [, fmt])
    *    load(istream f [, fmt])
    *
    * @path The filename into which to save/load the streamed serialization.
    * @f    The stream with which to save/load the serialization.
    * @fmt  Format: One of following from enum SerializableFormat
-   *   BINARY   - A binary format which is the fastest but not portable between platforms (default).
-   *   PORTABLE - Another Binary format, not quite as fast but is portable between platforms.
-   *   JSON     - Human readable JSON text format. Slow.
-   *   XML      - Human readable XML text format. Even slower.
+   *   SerializableFormat::BINARY   - A binary format which is the fastest but not portable between platforms (default).
+   *   SerializableFormat::PORTABLE - Another Binary format, not quite as fast but is portable between platforms.
+   *   SerializableFormat::JSON     - Human readable JSON text format. Slow.
+   *   SerializableFormat::XML      - Human readable XML text format. Even slower.
+   * or an std::string, one of "BINARY", "PORTABLE", "JSON", "XML".
    *
-	 * See Serializable base class for more details.
+	 * See Serializable base class for more details (types/Serializable.hpp).
 	 */
   CerealAdapter;  // see Serializable.hpp
   // FOR Cereal Serialization

--- a/src/htm/types/Serializable.hpp
+++ b/src/htm/types/Serializable.hpp
@@ -224,8 +224,7 @@ public:
 
 
 
-
-  virtual inline void saveToFile(std::string filePath, SerializableFormat fmt=SerializableFormat::BINARY) const {
+  virtual inline void saveToFile(std::string filePath, SerializableFormat fmt) const {
     std::string dirPath = Path::getParent(filePath);
 	  Directory::create(dirPath, true, true);
 		std::ios_base::openmode mode = std::ios_base::out;
@@ -236,6 +235,19 @@ public:
 		save(out, fmt);
 		out.close();
 	}
+  virtual inline void saveToFile(std::string filePath) const {
+    // pybind11 was having problems with the default so making it a separate function.
+    saveToFile(filePath, SerializableFormat::BINARY);
+  }
+  virtual inline void saveToFile(std::string filePath, std::string fmt) const {
+    SerializableFormat fmt1;
+    if      (fmt == "BINARY")   fmt1 =  SerializableFormat::BINARY;
+    else if (fmt == "PORTABLE") fmt1 =  SerializableFormat::PORTABLE;
+    else if (fmt == "JSON")     fmt1 =  SerializableFormat::JSON;
+    else if (fmt == "XML")      fmt1 =  SerializableFormat::XML;
+    else NTA_THROW << "saveToFile(): Invalid serialization format. Expecting 'BINARY', 'PORTABLE', 'JSON', or 'XML'.";
+    saveToFile(filePath, fmt1);
+  }  
 
   // NOTE: for BINARY and PORTABLE the stream must be ios_base::binary or it will crash on Windows.
   virtual inline void save(std::ostream &out, SerializableFormat fmt=SerializableFormat::BINARY) const {
@@ -267,7 +279,7 @@ public:
 		}
   }
 
-  virtual inline void loadFromFile(std::string filePath, SerializableFormat fmt=SerializableFormat::BINARY) {
+  virtual inline void loadFromFile(std::string filePath, SerializableFormat fmt) {
 		std::ios_base::openmode mode = std::ios_base::in;
 		if (fmt <= SerializableFormat::PORTABLE) mode |= std::ios_base::binary;
 	  std::ifstream in(filePath, mode);
@@ -277,6 +289,21 @@ public:
 		load(in, fmt);
 		in.close();
 	}
+  virtual inline void loadFromFile(std::string filePath) {
+    // pybind11 was having problems with the default so making it a separate function.
+    loadFromFile(filePath, SerializableFormat::BINARY);
+  }
+  virtual inline void loadFromFile(std::string filePath, std::string fmt) {
+    SerializableFormat fmt1;
+    if      (fmt == "BINARY")   fmt1 =  SerializableFormat::BINARY;
+    else if (fmt == "PORTABLE") fmt1 =  SerializableFormat::PORTABLE;
+    else if (fmt == "JSON")     fmt1 =  SerializableFormat::JSON;
+    else if (fmt == "XML")      fmt1 =  SerializableFormat::XML;
+    else NTA_THROW << "loadFromFile(): Invalid serialization format. Expecting 'BINARY', 'PORTABLE', 'JSON', or 'XML'.";
+
+    loadFromFile(filePath, fmt1);
+  }  
+
   // NOTE: for BINARY and PORTABLE the stream must opened with ios_base::binary or it will crash on Windows.
   //       Stream exceptions should NOT be set.
 	virtual inline void load(std::istream &in,  SerializableFormat fmt=SerializableFormat::BINARY) {

--- a/src/test/unit/ntypes/ValueTest.cpp
+++ b/src/test/unit/ntypes/ValueTest.cpp
@@ -167,7 +167,7 @@ TEST(ValueTest, asMap) {
     ss << itr->first << "=" << itr->second;
   }
   result = ss.str();
-  std::cout << result << "\n";
+  //std::cout << result << "\n";
   EXPECT_STREQ(result.c_str(), "scalar=456, string=is a scalar.");
 }
 


### PR DESCRIPTION
This provides Python access to saveToFile(file, fmt) and loadFromFile(file, fmt) with fmt as a string.  fmt is one of "BINARY", "PORTABLE", "JSON", or "XML".

