### PR TITLE
implemented category and sparsity parameters in ScalarEncoderRegion

### DIFF
--- a/src/examples/rest/client.cpp
+++ b/src/examples/rest/client.cpp
@@ -41,12 +41,16 @@
 #include <cstring>
 
 // save diagnostic state
+#ifdef GCC
 #pragma GCC diagnostic push
 // turn off the specific warning. Can also use "-Wall"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #include <httplib.h>
 // turn back on the compiler warnings
 #pragma GCC diagnostic pop
+#else
+#include <httplib.h>
+#endif
 
 //#define CA_CERT_FILE "./ca-bundle.crt"
 #define DEFAULT_PORT 8050

--- a/src/htm/encoders/ScalarEncoder.cpp
+++ b/src/htm/encoders/ScalarEncoder.cpp
@@ -199,6 +199,7 @@ std::ostream & operator<<(std::ostream & out, const ScalarEncoder &self)
   out << "  periodic:  " << self.parameters.periodic   << ",\n";
   out << "  category:  " << self.parameters.category   << ",\n";
   out << "  activeBits:" << self.parameters.activeBits << ",\n";
+  out << "  sparsity:"   << self.parameters.sparsity   << ",\n";
   out << "  resolution:" << self.parameters.resolution << std::endl;
   return out;
 }

--- a/src/htm/regions/ScalarEncoderRegion.cpp
+++ b/src/htm/regions/ScalarEncoderRegion.cpp
@@ -214,7 +214,7 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
                                   ParameterSpec::CreateAccess));
   ns->parameters.add("sparsity",
                     ParameterSpec(
-                                  "How sparce it is as a ratio of active bits to size."
+                                  "Sparsity is the number of active bits divided by the total number of bits. "
                                   "Use one of: 'activeBits' or 'sparsity'.",
                                   NTA_BasicType_Real32,
                                   1,       // elementCount

--- a/src/htm/regions/ScalarEncoderRegion.cpp
+++ b/src/htm/regions/ScalarEncoderRegion.cpp
@@ -33,14 +33,16 @@ namespace htm {
 
 ScalarEncoderRegion::ScalarEncoderRegion(const ValueMap &params, Region *region)
     : RegionImpl(region) {
-  params_.size = params.getScalarT<UInt32>("size", params.getScalarT<UInt32>("n", 0));
-  params_.activeBits = params.getScalarT<UInt32>("activeBits", params.getScalarT<UInt32>("w", 0));
-  params_.resolution = params.getScalarT<Real64>("resolution", 0.0);
-  params_.radius = params.getScalarT<Real64>("radius", 0.0);
   params_.minimum = params.getScalarT<Real64>("minValue", -1.0);
   params_.maximum = params.getScalarT<Real64>("maxValue", +1.0);
-  params_.periodic = params.getScalarT<bool>("periodic", false);
   params_.clipInput = params.getScalarT<bool>("clipInput", false);
+  params_.periodic = params.getScalarT<bool>("periodic", false);
+  params_.category = params.getScalarT<bool>("category", false);
+  params_.activeBits = params.getScalarT<UInt32>("activeBits", params.getScalarT<UInt32>("w", 0));
+  params_.sparsity = params.getScalarT<Real32>("sparsity", 0.0);
+  params_.size = params.getScalarT<UInt32>("size", params.getScalarT<UInt32>("n", 0));
+  params_.radius = params.getScalarT<Real64>("radius", 0.0);
+  params_.resolution = params.getScalarT<Real64>("resolution", 0.0);
 
   encoder_ = std::make_shared<ScalarEncoder>( params_ );
 
@@ -132,7 +134,8 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
                                    ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add("size", 
-                     ParameterSpec("The length of the encoding. Size of buffer",
+                     ParameterSpec("The length of the encoding. Size of buffer. "
+                                   "Use one of: 'size', 'radius', 'resolution', or 'category'.",
                                         NTA_BasicType_UInt32,
                                         1,   // elementCount
                                         "",  // constraints
@@ -146,7 +149,9 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
                                         ParameterSpec::CreateAccess));
 
   ns->parameters.add("activeBits", 
-                     ParameterSpec("The number of active bits in the encoding. i.e. how sparse", NTA_BasicType_UInt32,
+                     ParameterSpec("The number of active bits in the encoding. i.e. how sparse is it."
+                                   "Use one of: 'activeBits' or 'sparsity'.",
+                                   NTA_BasicType_UInt32,
                                    1,   // elementCount
                                    "",  // constraints
                                    "0", // defaultValue
@@ -159,14 +164,16 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
                                    ParameterSpec::CreateAccess));
 
   ns->parameters.add("resolution",
-                     ParameterSpec("The resolution for the encoder",
+                     ParameterSpec("The resolution for the encoder "
+                                   "Use one of: 'size', 'radius', 'resolution', or 'category'.",
                                    NTA_BasicType_Real64,
                                    1,   // elementCount
                                    "",  // constraints
                                    "0", // defaultValue
                                    ParameterSpec::CreateAccess));
 
-  ns->parameters.add("radius", ParameterSpec("The radius for the encoder",
+  ns->parameters.add("radius", ParameterSpec("The radius for the encoder. "
+                                   "Use one of: 'size', 'radius', 'resolution', or 'category'.",
                                   NTA_BasicType_Real64,
                                   1,   // elementCount
                                   "",  // constraints
@@ -205,6 +212,23 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
                                   "",      // constraints
                                   "false", // defaultValue
                                   ParameterSpec::CreateAccess));
+  ns->parameters.add("sparsity",
+                    ParameterSpec(
+                                  "How sparce it is as a ratio of active bits to size."
+                                  "Use one of: 'activeBits' or 'sparsity'.",
+                                  NTA_BasicType_Real32,
+                                  1,       // elementCount
+                                  "",      // constraints
+                                  "false", // defaultValue
+                                  ParameterSpec::CreateAccess));
+  ns->parameters.add("category",
+                     ParameterSpec("Whether the encoder parameter is a category. "
+                                   "Use one of: 'size', 'radius', 'resolution', or 'category'.",
+                                   NTA_BasicType_Bool,
+                                   1,       // elementCount
+                                   "",      // constraints
+                                   "false", // defaultValue
+                                   ParameterSpec::CreateAccess));
 
    /* ----- inputs ------- */
   ns->inputs.add("values",
@@ -237,7 +261,8 @@ ScalarEncoderRegion::~ScalarEncoderRegion() {}
 Real64 ScalarEncoderRegion::getParameterReal64(const std::string &name, Int64 index) const {
   if (name == "sensedValue") {
     return sensedValue_;
-  } else if (name == "resolution") return encoder_->parameters.resolution;
+  } else if (name == "resolution") 
+    return encoder_->parameters.resolution;
   else if (name == "radius")
     return encoder_->parameters.radius;
   else if (name == "minValue")
@@ -249,11 +274,21 @@ Real64 ScalarEncoderRegion::getParameterReal64(const std::string &name, Int64 in
   }
 }
 
+Real32 ScalarEncoderRegion::getParameterReal32(const std::string &name, Int64 index) const {
+  if (name == "sparsity") 
+    return encoder_->parameters.sparsity;
+  else {
+    return RegionImpl::getParameterReal32(name, index);
+  }
+}
+
 bool ScalarEncoderRegion::getParameterBool(const std::string& name, Int64 index) const {
   if (name == "periodic") 
     return encoder_->parameters.periodic;
   if (name == "clipInput")
     return encoder_->parameters.clipInput;
+  if (name == "category")
+    return encoder_->parameters.category;
   else {
     return RegionImpl::getParameterBool(name, index);
   }
@@ -262,8 +297,7 @@ bool ScalarEncoderRegion::getParameterBool(const std::string& name, Int64 index)
 UInt32 ScalarEncoderRegion::getParameterUInt32(const std::string &name, Int64 index) const {
   if (name == "n" || name == "size") {
     return (UInt32)encoder_->size;
-  }
-  else if (name == "w" || name == "activeBits") {
+  } else if (name == "w" || name == "activeBits") {
     return encoder_->parameters.activeBits;
   } else {
     return RegionImpl::getParameterUInt32(name, index);
@@ -288,6 +322,7 @@ bool ScalarEncoderRegion::operator==(const RegionImpl &o) const {
   if (params_.periodic != other.params_.periodic) return false;
   if (params_.activeBits != other.params_.activeBits) return false;
   if (params_.sparsity != other.params_.sparsity) return false;
+  if (params_.category != other.params_.category) return false;
   if (params_.size != other.params_.size) return false;
   if (params_.radius != other.params_.radius) return false;
   if (params_.resolution != other.params_.resolution) return false;

--- a/src/htm/regions/ScalarEncoderRegion.hpp
+++ b/src/htm/regions/ScalarEncoderRegion.hpp
@@ -51,6 +51,7 @@ public:
   static Spec *createSpec();
 
   virtual Real64 getParameterReal64(const std::string &name, Int64 index = -1) const override;
+  virtual Real32 getParameterReal32(const std::string &name, Int64 index) const override;
   virtual UInt32 getParameterUInt32(const std::string &name, Int64 index = -1) const override;
   virtual bool getParameterBool(const std::string &name, Int64 index = -1) const override;
   virtual void setParameterReal64(const std::string &name, Int64 index, Real64 value) override;
@@ -76,6 +77,7 @@ public:
        cereal::make_nvp("size", params_.size),
        cereal::make_nvp("radius", params_.radius),
        cereal::make_nvp("resolution", params_.resolution),
+       cereal::make_nvp("category", params_.category),
        cereal::make_nvp("sensedValue_", sensedValue_));
   }
   // FOR Cereal Deserialization
@@ -95,6 +97,7 @@ public:
        cereal::make_nvp("size", params_.size),
        cereal::make_nvp("radius", params_.radius),
        cereal::make_nvp("resolution", params_.resolution),
+       cereal::make_nvp("category", params_.category),
        cereal::make_nvp("sensedValue_", sensedValue_));
     encoder_ = std::make_shared<ScalarEncoder>( params_ );
     setDimensions(encoder_->dimensions); 

--- a/src/test/unit/algorithms/AnomalyTest.cpp
+++ b/src/test/unit/algorithms/AnomalyTest.cpp
@@ -14,6 +14,10 @@
  * You should have received a copy of the GNU Affero Public License
  * along with this program.  If not, see http://www.gnu.org/licenses.
  * --------------------------------------------------------------------- */
+#ifdef MSVC
+#pragma warning(                                                                                                       \
+    disable : 4244) // warning C4244: '=': conversion from 'double' to 'unsigned char', possible loss of data
+#endif
 
 #include <algorithm>
 #include <vector>

--- a/src/test/unit/regions/ScalarEncoderRegionTest.cpp
+++ b/src/test/unit/regions/ScalarEncoderRegionTest.cpp
@@ -52,7 +52,7 @@
 #define VERBOSE if(verbose)std::cerr << "[          ] "
 static bool verbose = false;  // turn this on to print extra stuff for debugging the test.
 
-const UInt EXPECTED_SPEC_COUNT =  11u;  // The number of parameters expected in the ScalarSensor Spec
+const UInt EXPECTED_SPEC_COUNT =  13u;  // The number of parameters expected in the ScalarSensor Spec
 
 using namespace htm;
 namespace testing 
@@ -70,7 +70,7 @@ namespace testing
     VERBOSE << *ns << std::endl;
 
     std::shared_ptr<Region> region1 = net.addRegion("region1", "ScalarEncoderRegion", "{n: 100, w: 10}"); 
-    std::set<std::string> excluded = {"n", "w", "size", "activeBits", "resolution", "radius"};
+    std::set<std::string> excluded = {"n", "w", "size", "activeBits", "resolution", "radius", "sparsity"};
     checkGetSetAgainstSpec(region1, EXPECTED_SPEC_COUNT, excluded, verbose);
     checkInputOutputsAgainstSpec(region1, verbose);
   }
@@ -287,7 +287,7 @@ namespace testing
       "defaultValue": "-1"
     },
     "size": {
-      "description": "The length of the encoding. Size of buffer",
+      "description": "The length of the encoding. Size of buffer. Use one of: 'size', 'radius', 'resolution', or 'category'.",
       "type": "UInt32",
       "count": 1,
       "access": "Create",
@@ -301,7 +301,7 @@ namespace testing
       "defaultValue": "0"
     },
     "activeBits": {
-      "description": "The number of active bits in the encoding. i.e. how sparse",
+      "description": "The number of active bits in the encoding. i.e. how sparse is it.Use one of: 'activeBits' or 'sparsity'.",
       "type": "UInt32",
       "count": 1,
       "access": "Create",
@@ -315,14 +315,14 @@ namespace testing
       "defaultValue": "0"
     },
     "resolution": {
-      "description": "The resolution for the encoder",
+      "description": "The resolution for the encoder Use one of: 'size', 'radius', 'resolution', or 'category'.",
       "type": "Real64",
       "count": 1,
       "access": "Create",
       "defaultValue": "0"
     },
     "radius": {
-      "description": "The radius for the encoder",
+      "description": "The radius for the encoder. Use one of: 'size', 'radius', 'resolution', or 'category'.",
       "type": "Real64",
       "count": 1,
       "access": "Create",
@@ -351,6 +351,20 @@ namespace testing
     },
     "clipInput": {
       "description": "Whether to clip inputs if they're outside [minValue, maxValue]",
+      "type": "Bool",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "false"
+    },
+    "sparsity": {
+      "description": "How sparce it is as a ratio of active bits to size.Use one of: 'activeBits' or 'sparsity'.",
+      "type": "Real32",
+      "count": 1,
+      "access": "Create",
+      "defaultValue": "false"
+    },
+    "category": {
+      "description": "Whether the encoder parameter is a category. Use one of: 'size', 'radius', 'resolution', or 'category'.",
       "type": "Bool",
       "count": 1,
       "access": "Create",
@@ -385,6 +399,7 @@ namespace testing
   }
 })";
 
+       
     Spec *spec = ScalarEncoderRegion::createSpec();
     std::string json = spec->toString();
     EXPECT_STREQ(json.c_str(), expected.c_str());
@@ -402,7 +417,9 @@ namespace testing
   "minValue": -1.000000,
   "maxValue": 1.000000,
   "periodic": false,
-  "clipInput": false
+  "clipInput": false,
+  "sparsity": 0.040000,
+  "category": false
 })";
 
     Network net1;

--- a/src/test/unit/regions/ScalarEncoderRegionTest.cpp
+++ b/src/test/unit/regions/ScalarEncoderRegionTest.cpp
@@ -357,7 +357,7 @@ namespace testing
       "defaultValue": "false"
     },
     "sparsity": {
-      "description": "How sparce it is as a ratio of active bits to size.Use one of: 'activeBits' or 'sparsity'.",
+      "description": "Sparsity is the number of active bits divided by the total number of bits. Use one of: 'activeBits' or 'sparsity'.",
       "type": "Real32",
       "count": 1,
       "access": "Create",


### PR DESCRIPTION
response to Issue #939 
At some point in the past, parameters 'category' and 'sparsity' had been added to the ScalarEncoder class but they were not added to the NetworkAPI wrapper ScalarEncoderRegion.  This PR completes the change by adding them to ScalarEncoderRegion.
