### PR TITLE
add bindings for asVector()

### DIFF
--- a/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
+++ b/bindings/py/cpp_src/bindings/engine/py_Engine.cpp
@@ -67,7 +67,7 @@ namespace htm_ext
             .def(py::init<UInt, UInt, UInt>());
 
         // members
-        py_Dimensions.def("getCount", &Dimensions::getCount)
+        py_Dimensions.def("getCount", &Dimensions::getCount) 
             .def("size", &Dimensions::size)
             .def("empty", &Dimensions::empty)
             .def("clear", &Dimensions::clear)

--- a/py/tests/networkapi/dimensions_test.py
+++ b/py/tests/networkapi/dimensions_test.py
@@ -31,8 +31,8 @@ from htm.bindings.engine_internal import Dimensions
 class NetworkAPI_Dimensions_Test(unittest.TestCase):
   """ Unit tests for Dimensions class. """
 
-  def testStatus(self):
-    # test of the status conditions of a Dimensions object
+  def testDimensionsMembers(self):
+    # test of the status conditions of a Dimensions object  
     dim1 = Dimensions()
     self.assertEqual(dim1.empty(), True)
     self.assertEqual(dim1.size(), 0)


### PR DESCRIPTION
Responding to Issue #941
Added Python bindings for asVector( ) in Dimensions object.