### PR TITLE
Build releases for python versions 3.8 and 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 #TODO arm releases
 #TODO enable 32bit linux wheels builds?
 #TODO use older manylinux2010 for larger compatibility?
-#TODO support py27 wheels?
 
 on:
   push:
@@ -18,7 +17,7 @@ jobs:
     strategy:
       #max-parallel: 4
       matrix:
-        python-version: [3.7] #TODO we're not yet py3.8 ready!
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:


### PR DESCRIPTION
Now that we know python 3.9 works, we should build and release it for 3.8 and 3.9 on all platforms.