### PR TITLE
adding support for VS 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ VERSION
 
 # Test Output files
 bindings/py/tests/*.stream
+TestOutputDir/*
 
 # /
 /.gdb_history

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@
 # -----------------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 3.7...3.22.2)
-#    Means CMake 3.7 is minimum version but has been tested with CMake 3.22.2
+#    Means that CMake 3.7 is the minimum version but the build has been tested with CMake 3.22.2
+#    CMake versions higher than 3.22.2 are likely to work as well.
 
 project(htm_core CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@
 # along with this program.  If not, see http://www.gnu.org/licenses.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.7...3.22.2)
+#    Means CMake 3.7 is minimum version but has been tested with CMake 3.22.2
+
 project(htm_core CXX)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a Community Fork of the [nupic.core](https://github.com/numenta/nupic.co
 
 ## Features
 
- * Implemented in C++11 through C++17
+ * Implemented in C\+\+11 through C\+\+17
     + Static and shared lib files for use with C++ applications.
  * Interfaces to Python 3 and Python 2.7 (Only Python 3 under Windows)
  * Cross Platform Support for Windows, Linux, OSX and ARM64
@@ -43,7 +43,7 @@ in C++ library.
 ### Binary releases
 
 If you want to use `htm.core` from Python, the easiest method is to install from [PyPI](https://test.pypi.org/project/htm.core/)
-  - Note: to install from `pip` you'll need Python 3.7+ 
+  - Note: to install from `pip` you'll need Python 3.7 only(does not work with older or newer versions)
 
 ```
 python -m pip install -i https://test.pypi.org/simple/ htm.core
@@ -92,11 +92,13 @@ git clone https://github.com/htm-community/htm.core
 #### Prerequisites
 
 - same as for Binary releases, plus:
-- **C++ compiler**: c++11/17 compatible (ie. g++, clang++).
-- boost library (if not a C++17 compiler that supports filesystem.)
+- **C\+\+ compiler**: c\+\+11/17 compatible (ie. g++, clang\+\+).
+- boost library (if not a C\+\+17 or greater compiler that supports filesystem.) 
+  If the build needs boost, it will automatically download and install boost with the options it needs.
+- CMake 3.7+  (MSVC 2019 needs CMake 3.14+, MSVC 2022 needs CMake 3.21+).  
+  Install the latest using [https://cmake.org/download/](https://cmake.org/download/)
 
-Note: Windows MSVC 2019 runs as C++17 by default.  On linux use -std=c++17 compile option to 
-      avoid needing boost.
+Note: Windows MSVC 2019 runs as C\+\+17 by default so boost is not needed.  On linux use -std=c++17 compile option to avoid needing boost.
 
 
 #### Simple Python build (any platform)
@@ -111,8 +113,7 @@ Note: Windows MSVC 2019 runs as C++17 by default.  On linux use -std=c++17 compi
    * If you are using Anaconda Python you must run within the `Anaconda Prompt` on Windows. Do not use --user or --force options.
 
    * If you run into problems due to caching of arguments in CMake, delete the
-   folder `<path-to-repo>/build` and try again.  This may be only an issue when
-   developing C++ code.
+   folder `<path-to-repo>/build` and try again.  This may be only an issue when you restart a build after a failure.
 
 3) After that completes you are ready to import the library:
     ```python

--- a/startupMSVC.bat
+++ b/startupMSVC.bat
@@ -11,6 +11,7 @@ rem //     Microsoft Visual Studio 2017, 2019 or newer (any flavor)
 rem //
 rem //     CMake: 3.7+ Download CMake from https://cmake.org/download/
 rem //            NOTE: CMake 3.14+ is required for MSCV 2019
+rem //                  CMake 3.21+ is required for MSCV 2022
 rem //
 rem //     Python 2.7 or 3.x Download from https://www.python.org/downloads/windows/  (optional)
 rem // 
@@ -21,8 +22,9 @@ rem //
 rem //   Note: if you were originally using this repository with VS 2017 and you now
 rem //         want to use VS 2019, Do the following:
 rem //           1) delete the build folder in the repository.  This will remove the .sln and other VS files.
-rem //           2) run startupMSVC.bat again.   It will detect that VS 2019 is installed and configure for it but it will start VS 2017.
+rem //           2) run startupMSVC.bat again.   It will detect that VS 2019 is installed and configure for it but if not it will start VS 2017.
 rem //           3) after .sln is re-created in build/scripts/, right click, on the .sln file, select "open with", click "choose another app", select VS 2019
+rem //         The same applies for VS 2022.
 rem //
 rem // Tricks for executing Visual Studio in Release or Build mode.
 rem // https://stackoverflow.com/questions/24460486/cmake-build-type-not-being-used-in-cmakelists-txt
@@ -30,14 +32,24 @@ rem // https://stackoverflow.com/questions/24460486/cmake-build-type-not-being-u
   
 :CheckCMake
 rem  // make sure CMake is installed.  (version 3.7 minimum)
-cmake -version > NUL 2> NUL 
+cmake -version > cmake_version.txt 
 if %errorlevel% neq 0 (
   @echo startup.bat;  CMake was not found. 
   @echo Download and install from  https://cmake.org/download/
   @echo Make sure its path is in the system PATH environment variable.
   pause
+  del cmake_version.txt
   exit /B 1
 )
+set /p ver=<cmake_version.txt
+set "ver=%ver:* =%"
+set "ver=%ver:* =%"
+set "ver=%ver:.= %"
+for /f "tokens=1*" %%a in ("%ver%") do set pri=%%a & set ver=%%b
+for /f "tokens=1*" %%a in ("%ver%") do set sec=%%a
+set /a cmake_version = pri*100 + sec
+del cmake_version.txt
+rem echo "cmake version=%cmake_version%"
 
 rem // position to full path of HTM_BASE (the repository)
 pushd %~dp0
@@ -68,6 +80,7 @@ if exist "htm_core.sln" (
 "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -legacy -prerelease -format json > vswhereTmp.jsn
 find /c "VisualStudio.15" vswhereTmp.jsn > vswhereTmp.cnt && (set Has2017=1) || (set Has2017=0)
 find /c "VisualStudio.16" vswhereTmp.jsn > vswhereTmp.cnt && (set Has2019=1) || (set Has2019=0)
+find /c "VisualStudio.17" vswhereTmp.jsn > vswhereTmp.cnt && (set Has2022=1) || (set Has2022=0)
 del vswhereTmp.*
 
 rem // Run CMake using the Visual Studio generator.  The generator can be one of these.
@@ -77,9 +90,11 @@ rem //
 rem //   cmake -G "Visual Studio 16 2019" -A x64
 rem //   cmake -G "Visual Studio 16 2019" -A ARM64
 rem //      NOTE: MSVC 2019 tool set generator requires CMake V3.14 or greater)
+rem //
+rem //   cmake -G "Visual Studio 17 2022" -A x64
 rem //   
 rem //  arguments:
-rem //   -G "Visual Studio 16 2019" -A x64   Sets the generator toolset and platform (compilers/linkers) to use. 
+rem //   -G "Visual Studio 16 2022" -A x64   Sets the generator toolset and platform (compilers/linkers) to use. 
 rem //   -Thost=x64                  Tell CMake to tell VS to use 64bit tools for compiler and linker
 rem //   --config "Release"          Start out in Release mode
 rem //   -DCMAKE_CONFIGURATION_TYPES="Debug;Release"   Specify the build types allowed.
@@ -87,16 +102,41 @@ rem //   ../..                       set the source directory (top of repository
 rem //
 rem //  NOTE: only 64bit compiles supported.
 
-if %Has2019%==1 (
-    cmake -G "Visual Studio 16 2019" -A x64 -Thost=x64 --config "Release" -DCMAKE_CONFIGURATION_TYPES="Release;Debug"  ../..
-) else (
-    if %Has2017%==1 (
-      cmake -G "Visual Studio 15 2017 Win64" -Thost=x64 --config "Release" -DCMAKE_CONFIGURATION_TYPES="Release;Debug"  ../..
+if %Has2022%==1 (
+    if %cmake_version% GEQ 321 (
+      cmake -G "Visual Studio 17 2022" -A x64 -Thost=x64 --config "Release" -DCMAKE_CONFIGURATION_TYPES="Release;Debug"  ../..
     ) else (
-      @echo Did not fond Visual studio 2017 or Visual Studio 2019.
-      popd
-      pause
-      exit /B 1
+          @echo Visual Studio 2022 requires CMake 3.21 or higher.
+          popd
+          pause
+          exit /B 1
+    )
+) else (
+    if %Has2019%==1 (
+        if %cmake_version% GEQ 314 (
+            cmake -G "Visual Studio 16 2019" -A x64 -Thost=x64 --config "Release" -DCMAKE_CONFIGURATION_TYPES="Release;Debug"  ../..
+        ) else (
+              @echo Visual Studio 2019 requires CMake 3.14 or higher.
+              popd
+              pause
+              exit /B 1
+        )
+    ) else (
+        if %Has2017%==1 (
+          if %cmake_version% GEQ 307 (
+              cmake -G "Visual Studio 15 2017 Win64" -Thost=x64 --config "Release" -DCMAKE_CONFIGURATION_TYPES="Release;Debug"  ../..
+          ) else (
+                @echo Visual Studio 2017 requires CMake 3.7 or higher.
+                popd
+                pause
+                exit /B 1
+          )
+        ) else (
+          @echo Did not fond Visual studio 2017, 2019 or 2022.
+          popd
+          pause
+          exit /B 1
+        )
     )
 )
 


### PR DESCRIPTION
Modified the build to add support for building on Microsoft Visual Studio 2022.
This also adds checks for the CMake version since each Visual Studio version requires a different minimum CMake version.

See Issue #967 