### PR TITLE
Location module and ApicalTiebreakMemoryCPP

### DIFF
--- a/py/htm/advanced/regions/ApicalTMPairRegion.py
+++ b/py/htm/advanced/regions/ApicalTMPairRegion.py
@@ -411,11 +411,12 @@ class ApicalTMPairRegion(PyRegion):
                 "seed": self.seed,
             }
 
-            if self.implementation == "ApicalTiebreakCPP": # TODO
+            if self.implementation == "ApicalTiebreakCPP":
                 params["learnOnOneCell"] = self.learnOnOneCell
                 params["maxSegmentsPerCell"] = self.maxSegmentsPerCell
 
-                cls = ApicalTiebreakPairMemory
+                import nupic.bindings.algorithms
+                cls = nupic.bindings.algorithms.ApicalTiebreakPairMemory
 
             elif self.implementation == "ApicalTiebreak":
                 params["reducedBasalThreshold"] = self.reducedBasalThreshold

--- a/py/htm/advanced/regions/ApicalTMSequenceRegion.py
+++ b/py/htm/advanced/regions/ApicalTMSequenceRegion.py
@@ -360,11 +360,12 @@ class ApicalTMSequenceRegion(PyRegion):
                 "seed": self.seed,
             }
 
-            if self.implementation == "ApicalTiebreakCPP": #TODO
+            if self.implementation == "ApicalTiebreakCPP":
                 params["learnOnOneCell"] = self.learnOnOneCell
                 params["maxSegmentsPerCell"] = self.maxSegmentsPerCell
 
-                cls = ApicalTiebreakSequenceMemory
+                import nupic.bindings.algorithms
+                cls = nupic.bindings.algorithms.ApicalTiebreakSequenceMemory
 
             elif self.implementation == "ApicalTiebreak":
                 params["reducedBasalThreshold"] = self.reducedBasalThreshold


### PR DESCRIPTION
These changes deal with two issues.
Firstly, somehow I missed an important method in Superficial2DLocationModule when I originally ported the htmresearch code to Pyhton3 and then to htm.core.
Secondly, in the same port I left a TODO in ApicalTMPairRegion and ApicalTMSequenceRegion to use CPP versions of ApicalTiebreakMemory since C++ is out of my comfort zone. 
Recently, Numenta ported the htmresearch-core code, including ApicalTiebreakMemoryCPP to Python3 and put it in the repository [nupic.research.core](https://github.com/numenta/nupic.research.core). So this finally enabled dealing with the TODO and so now the ApicalTiebreakMemory CPP code can be used from htm.core. 
Not to worry, nupic.research.core is not a requirement for building or using htm.core. 

The changes pass all the unit tests.