### PR TITLE
Correction to incorrect integer divide in location_module

### DIFF
--- a/py/htm/advanced/algorithms/location_modules.py
+++ b/py/htm/advanced/algorithms/location_modules.py
@@ -775,11 +775,11 @@ class Superficial2DLocationModule(AbstractLocationModule):
              for jOffset in self.cellCoordinateOffsets]
         )
         if "corners" in self.anchoringMethod:
-            self.bumpPhases = activatedCoords // self.cellDimensions
+            self.bumpPhases = activatedCoords / self.cellDimensions
 
         else:
             if activatedCoords.size > 0:
-                self.bumpPhases = np.append(self.bumpPhases,activatedCoords // self.cellDimensions, axis=0)
+                self.bumpPhases = np.append(self.bumpPhases,activatedCoords / self.cellDimensions, axis=0)
 
         self._computeActiveCells()
         self.activeSegments = activeSegments


### PR DESCRIPTION
I previously incorrectly replaced normal divide with integer in the missing method I added to location_module in my last pull request.