### PR TITLE
Remove unused import statements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ import glob
 import os
 import subprocess
 import sys
-import tempfile
-import distutils.dir_util
 import json
 
 from setuptools import Command, find_packages, setup


### PR DESCRIPTION
Neither of these things were referenced in the setup.py script, other than by their import statements so I removed them.
I have not tested this at all but it seems pretty safe to do.

This should fix the following warning:
```
UserWarning: Distutils was imported before Setuptools. This usage is
discouraged and may exhibit undesirable behaviors or errors. Please
use Setuptools’ objects directly or at least import Setuptools first.
```