### PR TITLE
Remove the -Werror flag.

### DIFF
--- a/CommonCompilerConfig.cmake
+++ b/CommonCompilerConfig.cmake
@@ -279,7 +279,7 @@ else()
 	set(cxx_flags_unoptimized ${cxx_flags_unoptimized} ${stdlib_cxx})
 
 	set(cxx_flags_unoptimized ${cxx_flags_unoptimized} ${stdlib_common} -fdiagnostics-show-option)
-	set (internal_compiler_warning_flags ${internal_compiler_warning_flags} -Werror -Wextra -Wreturn-type -Wunused -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers)
+	set (internal_compiler_warning_flags ${internal_compiler_warning_flags} -Wextra -Wreturn-type -Wunused -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers)
 
 	CHECK_CXX_COMPILER_FLAG(-m${BITNESS} compiler_supports_machine_option)
 	if (compiler_supports_machine_option)
@@ -358,7 +358,7 @@ else()
 	set(debug_specific_linker_flags)
 
 	if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-	  set (debug_specific_compile_flags ${debug_specific_compile_flags} -g)
+	  set (debug_specific_compile_flags ${debug_specific_compile_flags} -g -Werror)
 
 	  set(debug_specific_linker_flags ${debug_specific_linker_flags} -O0)
 

--- a/CommonCompilerConfig.cmake
+++ b/CommonCompilerConfig.cmake
@@ -163,7 +163,7 @@ if(MSVC)
 	#      Debug Only:       /Od /Zi /sdl /RTC1 /MDd
 	set(INTERNAL_CXX_FLAGS /permissive- /W3 /Gm- /EHsc /FC /nologo /Zc:__cplusplus
 							$<$<CONFIG:Release>:/O2 /Oi /Gy  /GL /MD> 
-							$<$<CONFIG:Debug>:/Ob0 /Od /Zi /sdl /RTC1 /MDd>)
+							$<$<CONFIG:Debug>:/Ob0 /Od /Zi /sdl /WX /RTC1 /MDd>)
 	#linker flags
 	if("${BITNESS}" STREQUAL "32")
 		set(machine "-MACHINE:X86")


### PR DESCRIPTION
The compiler flag "-Werror" converts all warnings into errors.

This was good back when we had CI & prebuilt binaries, because the CI would fail, forcing us -the developers- to fix all warnings on all of the platforms, and the users did not have to deal with the warnings because most of them used the prebuilt binaries.

However, now that the best advice is for users to build from source this is causing problems.
Deprecation warnings in particular are making the library unusable despite the fact that the deprecated functions are still present.
To make matters worse, the warnings are different for each platform / compiler, so without CI we can't test that any changes won't break the build.

On the other hand, as a matter of policy for this project, I think we should still endevour to have no warnings?
The compromise that I've implemented in this PR is to enable the `-Werror` flag for Debug mode builds.

However, I've only implemented this for the unix-like systems. I do not know how to configure MSVC.

---

@dkeeney,
Do you agree with this course of action?
If so can you fix up the cmake flags for MSVC?

Thank you