### PR TITLE
Missing pip leads to failure in building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN apk add --update  \
     g++ \
     git \
     python3-dev \
-    py3-numpy 
+    py3-numpy \
+    py3-pip
 
 ADD . /usr/local/src/htm.core
 WORKDIR /usr/local/src/htm.core


### PR DESCRIPTION
I encountered the following error message when building a Docker image. 
By adding py3-pip, I was able to resolve this issue.
```
root@htmdocker:~/htm.docker/htm.core# docker build --build-arg arch=amd64  .
[+] Building 10.7s (11/18)                                                                                                                         
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 2B                                                                                                               0.0s
 => [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 2.48kB                                                                                                        0.0s
 => [internal] load metadata for docker.io/multiarch/alpine:amd64-latest-stable                                                               0.7s
 => [build  1/14] FROM docker.io/multiarch/alpine:amd64-latest-stable@sha256:46847607e30096a3f365d9944dddccf60f1b9bf3fb1383694c25a470345f524  0.0s
 => [internal] load build context                                                                                                             0.0s
 => => transferring context: 884.14kB                                                                                                         0.0s
 => CACHED [build  2/14] RUN echo "Building HTM foramd64" && uname -a                                                                         0.0s
 => CACHED [build  3/14] RUN apk add --update      cmake     make     g++     git     python3-dev     py3-numpy                               0.0s
 => [build  4/14] ADD . /usr/local/src/htm.core                                                                                               4.3s
 => [build  5/14] WORKDIR /usr/local/src/htm.core                                                                                             5.0s
 => [build  6/14] RUN ln -s /usr/bin/python3 /usr/local/bin/python && python --version                                                        0.3s
 => ERROR [build  7/14] RUN python -m pip install --upgrade setuptools pip wheel                                                              0.4s
------
 > [build  7/14] RUN python -m pip install --upgrade setuptools pip wheel:
#0 0.387 /usr/local/bin/python: No module named pip
------
Dockerfile:45
--------------------
  43 |     RUN ln -s /usr/bin/python3 /usr/local/bin/python && python --version 
  44 |     
  45 | >>> RUN python -m pip install --upgrade setuptools pip wheel
  46 |     
  47 |     # Install
--------------------
ERROR: failed to solve: process "/bin/sh -c python -m pip install --upgrade setuptools pip wheel" did not complete successfully: exit code: 1
```