### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -435,7 +435,6 @@ if __name__ == "__main__":
     ext_modules=[Extension('htm.dummy', sources = ['dummy.c'])],
     package_dir = {"": "src"},
     packages=find_packages("src"),
-    namespace_packages=["htm"],
     install_requires=findRequirements(platform),
     package_data={
         "htm.bindings": ["*.so", "*.pyd"],


### PR DESCRIPTION
This removes the "namespace_package" which should not have been there. It prevents the top level "__init__.py" from being included in any packaged distributions.

https://packaging.python.org/en/latest/guides/packaging-namespace-packages/