### PR TITLE
Attempting to Fix Faulty Comparison in Union Path Integration Experiment

### DIFF
--- a/py/htm/advanced/examples/union_path_integration/multi_column_convergence.py
+++ b/py/htm/advanced/examples/union_path_integration/multi_column_convergence.py
@@ -244,6 +244,44 @@ class MultiColumnExperiment(PyExperimentSuite):
         """
         return self.network.getL2Representations()
 
+    def isObjectClassified(self, objectName, minOverlap=None, maxL2Size=None):
+        """
+        Return True if objectName is currently unambiguously classified by every L2
+        column. Classification is correct and unambiguous if the current L2 overlap
+        with the true object is greater than minOverlap and if the size of the L2
+        representation is no more than maxL2Size
+
+        :param minOverlap: min overlap to consider the object as recognized.
+                                             Defaults to half of the SDR size
+
+        :param maxL2Size: max size for the L2 representation
+                                            Defaults to 1.5 * SDR size
+
+        :return: True/False
+        """
+        l2sdr = self.getL2Representations()
+        try:
+            objectRepresentation = self.learnedObjects[objectName]
+        except:
+            return False
+        
+        if minOverlap is None:
+            minOverlap = self.sdrSize // 2
+        if maxL2Size is None:
+            maxL2Size = 1.5 * self.sdrSize
+
+        numCorrectClassifications = 0
+        for col in range(self.numColumns):
+            # Ignore inactive column
+            if len(l2sdr[col]) == 0:
+                continue
+
+            overlapWithObject = len(objectRepresentation[col] & l2sdr[col])
+            if (overlapWithObject >= minOverlap and len(l2sdr[col]) <= maxL2Size):
+                numCorrectClassifications += 1
+
+        return numCorrectClassifications == self.numColumns
+
 def plotSensationByColumn(suite, name):
     """
     Plots the convergence graph: touches by columns.

--- a/py/htm/advanced/examples/union_path_integration/multi_column_convergence.py
+++ b/py/htm/advanced/examples/union_path_integration/multi_column_convergence.py
@@ -231,7 +231,7 @@ class MultiColumnExperiment(PyExperimentSuite):
             if self.debug:
                 self.network.updateInferenceStats(stats, objectName=objName)
 
-            if touches is None and self.network.isObjectClassified(objName, minOverlap=30):
+            if touches is None and self.isObjectClassified(objName, minOverlap=30):
                 touches = sensation + 1
                 if not self.debug:
                     return touches


### PR DESCRIPTION
While running multi_column_convergence.py in the Union Path Integration experiment folder, there appears to be an issue with the inference stage of the experiment where no proper comparison occurs in the isObjectClassified function called on line 234 of the file. In the current version of the file, that function is part of the network object. However, in line 666 of location_network_creation.py, that function tries to store self.learnedObjects[objectName] into a variable called objectRepresentation. However, this fails subsequently returning False from line 668 as self.learnedObjects is part of the experiment class, not the network class. The end result of this problem is the infer function of multi_column_convergence.py will return self.numOfSensations (a pre-configured parameter which is the maximum number of allowed sensations to identify a given object) as there is never any proper comparison between the inferred representation and the previously learned object due to the inability to reference self.learnedObjects from the experiment class in the network class. So currently, the inference function returns 9 and the resulting plot will show 9 touches in literally any case due to the faulty comparison. 

One potential solution that I found worked was to copy the isObjectClassified function and move it into the experiment class. Then change line 234 of the experiment file to reference this version of the function instead of the network’s version. Now a comparison is being made between the inferred representation and the learned representation and the result is not always 9 touches as before. There appear to be some more work to be done, but I think this solves the initial problem of no comparison. 