### PR TITLE
adjusted numpy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,7 @@ For running C++ apps/examples/tests from binary release: none.
 If you want to use python, then obviously:
 
 - [Python](https://python.org/downloads/)
-    - Standard Python 3.7+ (Recommend using the latest)  [Tested with 3.8, 3.11.1]
-    - Standard Python 2.7
-      + We recommend the latest version of 2.7 where possible, but the system version should be fine.
-      + Python 2 is Not Supported on Windows, use Python 3 instead.
-      + Python 2 is not tested by our CI anomore. It may still work but we don't test it. We expect to drop support for Python2 around 2020.
+    - Standard Python 3.7+ (Recommend using the latest)  [Tested with 3.8, 3.11.1, 3.12.4]
     - [Anaconda Python](https://www.anaconda.com/products/individual#Downloads) 3.7+
       + On windows you must run from within 'Anaconda Prompt' not 'Command Prompt'.
       + Anaconda Python is not tested in our CI.
@@ -67,12 +63,13 @@ If you want to use python, then obviously:
   - You will probably also want to setup a [https://docs.python.org/3/library/venv.html(venv environment).
 
 - **C\+\+ compiler**: c\+\+11/17 compatible (ie. g++, clang\+\+).
+    On Windows, tested with MSVC 2019, 2022
   - boost library (if not a C\+\+17 or greater compiler that supports filesystem.) 
     If the build needs boost, it will automatically download and install boost with the options it needs.
   - CMake 3.7+  (MSVC 2019 needs CMake 3.14+, MSVC 2022 needs CMake 3.21+).  
     Install the latest using [https://cmake.org/download/](https://cmake.org/download/)
 
-Note: Windows MSVC 2019 runs as C\+\+17 by default so boost is not needed.  On linux use -std=c++17 compile option to avoid needing boost.
+Note: Windows MSVC 2019 and up runs as C\+\+17 by default so boost is not needed.  On linux use -std=c++17 compile option to avoid needing boost.
 
 ### Building from Source
 
@@ -89,11 +86,15 @@ git clone https://github.com/htm-community/htm.core
 
 #### Simple Python build (any platform)
 
-1) Prerequisites: install the following python packages: 
-	  `python -m ensurepip --upgrade`
-      `python -m pip install setuptools packaging`
-	  `pip -r install requirements.txt`
-
+1) Prerequisites: install the following python packages:
+```
+    python -m ensurepip --upgrade
+    python -m pip install setuptools packaging
+    pip install -r requirements.txt
+```
+    Note: requirements.txt limits numpy to version 1.23. You can use a newer
+	      version (i.e. 2.x) if you use at least Python 3.9.
+		  
 2) At a command prompt, `cd` to the root directory of this repository.
 
 3) Run: `python setup.py install --user --force`

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pip>=22.3.1
 wheel>=0.38.4
 cmake>=3.14 #>=3.7, >=3.14 needed for MSVC 2019, >=3.21 needed for MSVC 2022
 ## for python bindings (in /bindings/py/)
-numpy>=1.23
+numpy==1.23   # For a newer numpy such as V2.x, you must be running at least Python 3.9
 pytest>=4.6.5 #4.6.x series is last to support python2, once py2 dropped, we can switch to 5.x 
 ## for python code (in /py/)
 hexy>=1.4.4 # for grid cell encoder

--- a/src/test/unit/algorithms/HelloSPTPTest.cpp
+++ b/src/test/unit/algorithms/HelloSPTPTest.cpp
@@ -20,7 +20,7 @@
 
 namespace testing {
 
-TEST(HelloSPTPTest, performance) {
+TEST(HelloSPTPTest, DISABLED_performance) {
   auto bench = examples::BenchmarkHelloSPTP();
   bench.run();
 }


### PR DESCRIPTION
Version number adjustments.

1) After the last PR, I manually ran a full build and regression test on Windows (VS 2022) and Linux (Ubuntu 22.04) and they were successful. Fred already ran it on macOS.

 however I found that the latest numpy version requires at least Python 3.9.  
I adjusted the requirements.txt to limit the version of numpy to V1.23 so that the minimum remains at Python V3.7.  

However, we could also change the minimum Python version to Python 3.9, then we can use the latest numpy.  But on Ubuntu 22.04 (and probably others as well) the default is Python 3.8 and the build fails unless a newer Python is installed.

2) The HelloSPTPTest regression test still fails.  This is a performance test. However, on my slow machine (Intel i7 gen8) it runs too slow to pass the test.  It would be good to have a performance test that flags a PR that destroys performance but the test should not be dependent on the processor's speed.  So for now I disabled that test.

3) I also made some corrections to the README file.
