### PR TITLE
Added missing Python dependencies to the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ git clone https://github.com/htm-community/htm.core
     The Python portion of the build is performed in an isolated environment in a temp folder.
 	When the build completes, the build artifacts and cache are deleted.
 
+    Note that if you want to build in a virgin uv environment you will need to install at least 
+    `pip` in this environment and activate the environment. So the steps would be:
+    ```
+	cd <project directory>
+    uv venv --python <python version, e.g. 3.12>
+    uv pip install pip
+    source .venv/bin/activate
+	python htm_install.py
+    ```
+
+
 
 3) After the build completes you are ready to import the library:
     ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ classifiers = [
 dependencies = [
     "hexy>=1.4.4",
     "numpy>=2.0", 
-    "hexy>=1.4.4", 
     "prettytable>=3.5.0", 
     "wcwidth>=0.2.13"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,11 @@ classifiers = [
 ]
 
 dependencies = [
+    "hexy>=1.4.4",
     "numpy>=2.0", 
     "hexy>=1.4.4", 
     "prettytable>=3.5.0", 
+    "wcwidth>=0.2.13"
 ]
 
 [project.urls]


### PR DESCRIPTION
When I built the new version of htm.core in a uv environment earlier, it already was populated with all required dependencies so everything built correctly.
When I woke up to this and tested again in a virgin environment, the build failed.
Apparently `scikit_build_core` has no access to the builtin`pip` in uv and so `pip` must be installed manually into the environment beforehand. 
In addition, some dependencies are missing from the `pyproject.toml` that are needed for the Python stage of the build to complete (at least for uv on macOS).

This PR adds the missing dependencies needed to `pyproject.toml` as well as a note in the Readme about installing `pip` for a virgin uv environment.

All unit tests passed