### PR TITLE
Fix to Optimizer not running on MacOS

### DIFF
--- a/py/htm/optimization/ae.py
+++ b/py/htm/optimization/ae.py
@@ -510,7 +510,7 @@ class Worker(Process):
         print("Started: " + time.asctime( time.localtime(start_time) ) + '\n')
         # Setup memory limit
         if self.memory_limit is not None:
-            if not sys.platform.startswith('win'):
+            if not sys.platform.startswith('win') and not sys.platform.startswith('darwin'):
                 p = psutil.Process()
                 soft, hard = p.rlimit(psutil.RLIMIT_AS)
                 p.rlimit(psutil.RLIMIT_AS, (self.memory_limit, hard))


### PR DESCRIPTION
ae.py in the Optimizer calls psutilsl `rlimit()` but this service is not supported on MacOS.
This change checks for MacOS and bypasses the call to `rlimit()` if MacOS is detected.